### PR TITLE
Refactored ship/slap ad creation to use one tx

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -12,6 +12,8 @@ export type { STEAK } from './src/STEAK.js'
 export type { LookupQuestion } from './src/LookupQuestion.js'
 export type { LookupFormula } from './src/LookupFormula.js'
 export type { LookupAnswer } from './src/LookupAnswer.js'
+export type { Advertisement } from './src/Advertisement.js'
+export type { AdvertisementData } from './src/Advertiser.js'
 
 // The Knex storage system
 export { KnexStorage } from './src/storage/knex/KnexStorage.js'

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@bsv/gasp": "^0.1.2",
-        "@bsv/sdk": "^1.1.6",
+        "@bsv/sdk": "^1.1.12",
         "knex": "^3.1.0"
       },
       "devDependencies": {
@@ -607,9 +607,10 @@
       }
     },
     "node_modules/@bsv/sdk": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@bsv/sdk/-/sdk-1.1.6.tgz",
-      "integrity": "sha512-M08xzkMO0yz/X2MvrphEMEG4MOcJLk015wh1KMU/vur0upZqWWnsHHv94zwTL6O6tQHTnxMMLcIbvgSAed9r4w=="
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@bsv/sdk/-/sdk-1.1.12.tgz",
+      "integrity": "sha512-3nq04ACcoMG2l2u5kORMWAwIFkmzQWw4QuUSuBIz1nFj3wYDelkc5IlcqcBT3FnrIGwYYokGECjsJM02EcsjpA==",
+      "license": "SEE LICENSE IN LICENSE.txt"
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.0",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
   },
   "dependencies": {
     "@bsv/gasp": "^0.1.2",
-    "@bsv/sdk": "^1.1.6",
+    "@bsv/sdk": "^1.1.12",
     "knex": "^3.1.0"
   }
 }

--- a/src/Advertisement.ts
+++ b/src/Advertisement.ts
@@ -1,0 +1,8 @@
+export interface Advertisement {
+  protocol: 'SHIP' | 'SLAP'
+  identityKey: string
+  domain: string
+  topicOrService: string
+  beef?: number[]
+  outputIndex?: number
+}

--- a/src/Advertiser.ts
+++ b/src/Advertiser.ts
@@ -1,50 +1,42 @@
 import { Script } from '@bsv/sdk'
-import { SHIPAdvertisement } from './SHIPAdvertisement.js'
-import { SLAPAdvertisement } from './SLAPAdvertisement.js'
+import { Advertisement } from './Advertisement.js'
 import { TaggedBEEF } from './TaggedBEEF.js'
+
+export interface AdvertisementData {
+  protocol: 'SHIP' | 'SLAP'
+  topicOrServiceName: string
+}
 
 /**
  * Interface for managing SHIP and SLAP advertisements.
  * Provides methods for creating, finding, and revoking advertisements.
  */
 export interface Advertiser {
-  /**
-   * Creates a new SHIP advertisement for a given topic.
-   * @param topic - The topic name for the SHIP advertisement.
-   * @returns A promise that resolves to the created SHIP advertisement as TaggedBEEF.
-   */
-  createSHIPAdvertisement: (topic: string) => Promise<TaggedBEEF>
 
   /**
- * Creates a new SLAP advertisement for a given service.
- * @param service - The service name for the SLAP advertisement.
- * @returns A promise that resolves to the created SLAP advertisement as TaggedBEEF.
- */
-  createSLAPAdvertisement: (service: string) => Promise<TaggedBEEF>
+   * Creates a new SHIP/SLAP advertisement for a given topic.
+   * @param adsData - The data indicating the type of advertisement.
+   * @returns A promise that resolves to the created advertisement as TaggedBEEF.
+   */
+  createAdvertisements: (adsData: AdvertisementData[]) => Promise<TaggedBEEF>
 
   /**
-   * Finds all SHIP advertisements.
-   * @returns A promise that resolves to an array of SHIP advertisements.
+   * Finds all SHIP/SLAP advertisements.
+   * @returns A promise that resolves to an array of SHIP/SLAP advertisements.
    */
-  findAllSHIPAdvertisements: () => Promise<SHIPAdvertisement[]>
-
-  /**
-   * Finds all SLAP advertisements.
-   * @returns A promise that resolves to an array of SLAP advertisements.
-   */
-  findAllSLAPAdvertisements: () => Promise<SLAPAdvertisement[]>
+  findAllAdvertisements: (protocol: 'SHIP' | 'SLAP') => Promise<Advertisement[]>
 
   /**
    * Revokes an existing advertisement, either SHIP or SLAP.
-   * @param advertisement - The advertisement to revoke, either SHIP or SLAP.
+   * @param advertisements - The advertisements to revoke, either SHIP or SLAP.
    * @returns A promise that resolves to the revocation transaction as TaggedBEEF.
    */
-  revokeAdvertisement: (advertisement: SHIPAdvertisement | SLAPAdvertisement) => Promise<TaggedBEEF>
+  revokeAdvertisements: (advertisements: Advertisement[]) => Promise<TaggedBEEF>
 
   /**
    * Parses an output script to extract an advertisement.
    * @param outputScript - The script of the output to be parsed.
-   * @returns The parsed advertisement as a SHIPAdvertisement or SLAPAdvertisement, or null if the advertisement is invalid or cannot be parsed.
+   * @returns The parsed advertisement
    */
-  parseAdvertisement: (outputScript: Script) => SHIPAdvertisement | SLAPAdvertisement | null
+  parseAdvertisement: (outputScript: Script) => Advertisement
 }

--- a/src/SHIPAdvertisement.ts
+++ b/src/SHIPAdvertisement.ts
@@ -1,8 +1,0 @@
-export interface SHIPAdvertisement {
-  protocol: 'SHIP'
-  identityKey: string
-  domain: string
-  topic: string
-  beef?: number[]
-  outputIndex?: number
-}

--- a/src/SLAPAdvertisement.ts
+++ b/src/SLAPAdvertisement.ts
@@ -1,8 +1,0 @@
-export interface SLAPAdvertisement {
-  protocol: 'SLAP'
-  identityKey: string
-  domain: string
-  service: string
-  beef?: number[]
-  outputIndex?: number
-}


### PR DESCRIPTION
- Consolidated SHIP/SLAP advertisement definitions into a common interface
- Refactored `syncAdvertisements` to only use one tx per ad creation/revocation