### PR TITLE
WIP - Transaction context proposal

### DIFF
--- a/src/Engine.ts
+++ b/src/Engine.ts
@@ -191,8 +191,8 @@ export class Engine {
         await (async () => {
           try {
             this.startTime(`identifyAdmissibleOutputs_${txid.substring(0, 10)}`)
-            if (this.managers[topic].identifyExtendedAdmittanceInstructions) {
-              admissibleOutputs = await this.managers[topic].identifyExtendedAdmittanceInstructions?.(ctx)
+            if (this.managers[topic].identifyExtendedAdmissibleOutputs) {
+              admissibleOutputs = await this.managers[topic].identifyExtendedAdmissibleOutputs?.(ctx)
             } else {
               admissibleOutputs = await this.managers[topic].identifyAdmissibleOutputs(taggedBEEF.beef, previousCoins)
             }

--- a/src/Engine.ts
+++ b/src/Engine.ts
@@ -206,14 +206,14 @@ export class Engine {
         // Keep track of what outputs were admitted for what topic
         steak[topic] = admissibleOutputs
 
-        await Promise.all(outputs.map(async (output, vin) => {
+        await Promise.all(outputs.map(async (output, inputIndex) => {
           if (output !== undefined && output !== null) {
             try {
               await this.storage.markUTXOAsSpent(output.txid, output.outputIndex, topic)
               await Promise.all(Object.values(this.lookupServices).map(async l => {
                 try {
                   if (l.outputSpentExtended) {
-                    await l.outputSpentExtended(ctx, vin, topic)
+                    await l.outputSpentExtended(ctx, inputIndex, topic)
                   } else {
                     await l.outputSpent?.(output.txid, output.outputIndex, topic)
                   }

--- a/src/Engine.ts
+++ b/src/Engine.ts
@@ -133,6 +133,7 @@ export class Engine {
     const ctx: TransactionContext = {
       txid: txid,
       transaction: tx,
+      beef: taggedBEEF.beef,
       topicData: {}
     }
 

--- a/src/LookupService.ts
+++ b/src/LookupService.ts
@@ -1,5 +1,6 @@
 import { LookupFormula } from './LookupFormula.js'
 import { LookupQuestion, LookupAnswer, Script } from '@bsv/sdk'
+import { TransactionContext } from './TransactionContext.js'
 
 /**
  * Defines a Lookup Service interface to be implemented for specific use-cases
@@ -15,6 +16,7 @@ export interface LookupService {
    * @returns A promise that resolves when the processing of the new UTXO is complete.
    */
   outputAdded?: (txid: string, outputIndex: number, outputScript: Script, topic: string) => Promise<void>
+  outputAddedExtended?: (ctx: TransactionContext, outputIndex: number, topic: string) => Promise<void>
 
   /**
    * Processes the spend event for a UTXO.
@@ -26,6 +28,7 @@ export interface LookupService {
    * @returns A promise that resolves when processing is complete.
    */
   outputSpent?: (txid: string, outputIndex: number, topic: string) => Promise<void>
+  outputSpentExtended?: (ctx: TransactionContext, inputIndex: number, topic: string) => Promise<void>
 
   /**
    * Processes the deletion event for a UTXO.

--- a/src/TopicManager.ts
+++ b/src/TopicManager.ts
@@ -22,7 +22,7 @@ export interface TopicManager {
    * Returns instructions that denote which outputs from the provided transaction to admit into the topic, and which previous coins should be retained. 
    * Additionally, allows for the inclusion of arbitrary data parsed from inputs and outputs.
    */
-  identifyExtendedAdmittanceInstructions?: (ctx: TransactionContext) => Promise<ExtendedAdmittanceInstructions>  
+  identifyExtendedAdmissibleOutputs?: (ctx: TransactionContext) => Promise<ExtendedAdmittanceInstructions>  
 
   /**
    * Identifies other topic managers which must be run before this one is run.

--- a/src/TopicManager.ts
+++ b/src/TopicManager.ts
@@ -1,4 +1,5 @@
 import { AdmittanceInstructions } from '@bsv/sdk'
+import { ExtendedAdmittanceInstructions, TransactionContext } from './TransactionContext.js'
 
 /**
  * Defines a Topic Manager interface that can be implemented for specific use-cases
@@ -16,6 +17,18 @@ export interface TopicManager {
    * @throws - if there are no potentially valid topical outputs in this transaction
    */
   identifyNeededInputs?: (beef: number[]) => Promise<Array<{ txid: string, outputIndex: number }>>
+
+  /**
+   * Returns instructions that denote which outputs from the provided transaction to admit into the topic, and which previous coins should be retained. 
+   * Additionally, allows for the inclusion of arbitrary data parsed from inputs and outputs.
+   */
+  identifyExtendedAdmittanceInstructions?: (ctx: TransactionContext) => Promise<ExtendedAdmittanceInstructions>  
+
+  /**
+   * Identifies other topic managers which must be run before this one is run.
+   * @returns - A promise that resolves to an array of topic manager names.
+   */ 
+  getDependencies?: () => Promise<string[]>
 
   /**
   * Returns a Markdown-formatted documentation string for the topic manager.

--- a/src/TransactionContext.ts
+++ b/src/TransactionContext.ts
@@ -10,5 +10,6 @@ export interface ExtendedAdmittanceInstructions extends AdmittanceInstructions{
 export interface TransactionContext {
     txid: string
     transaction: Transaction
+    beef: number[]
     topicData: {[topic: string]: ExtendedAdmittanceInstructions}
 }

--- a/src/TransactionContext.ts
+++ b/src/TransactionContext.ts
@@ -4,7 +4,7 @@ import { AdmittanceInstructions, Transaction } from "@bsv/sdk";
 export interface ExtendedAdmittanceInstructions extends AdmittanceInstructions{
     inputData?: unknown[]
 
-    outputputData?: unknown[]
+    outputData?: unknown[]
 }
 
 export interface TransactionContext {

--- a/src/TransactionContext.ts
+++ b/src/TransactionContext.ts
@@ -1,0 +1,14 @@
+import { AdmittanceInstructions, Transaction } from "@bsv/sdk";
+
+
+export interface ExtendedAdmittanceInstructions extends AdmittanceInstructions{
+    inputData?: unknown[]
+
+    outputputData?: unknown[]
+}
+
+export interface TransactionContext {
+    txid: string
+    transaction: Transaction
+    topicData: {[topic: string]: ExtendedAdmittanceInstructions}
+}


### PR DESCRIPTION
Here's what I'm thinking for how context can be handled from both `TopicManager` and `LookupService`. `Extended` versions of several functions and types have been created to keep full backwards compatibility, at least until we can review and see decide if that makes sense. 

I made two minor changes to the flow as follows:
1. `topicPromises` array replaced with `topicPromisesMap` to allow for `TopicManager` to await dependencies.
2. pipelined `admissableOutputsPromise` -> `markSpentPromises` instead of `Promise.all([admissableOutputsPromise, markSpentPromises])` to allow `l.outputSpentExtended` to have access to `TransactionContext`