### PR TITLE
New Lookup Service interface

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bsv/overlay",
-  "version": "0.1.28",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bsv/overlay",
-      "version": "0.1.28",
+      "version": "0.2.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@bsv/gasp": "^1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@bsv/gasp": "^1.1.0",
-        "@bsv/sdk": "^1.4.18",
+        "@bsv/sdk": "^1.4.24",
         "knex": "^3.1.0"
       },
       "devDependencies": {
@@ -497,9 +497,9 @@
       }
     },
     "node_modules/@bsv/sdk": {
-      "version": "1.4.18",
-      "resolved": "https://registry.npmjs.org/@bsv/sdk/-/sdk-1.4.18.tgz",
-      "integrity": "sha512-CpBfPRpSij3og7qm9uPohzPmvRhiuRyGjh4NNfY4Vm3aVYcBOi1qz1h1iLyv6kLRFCoIgjq4E6CzTbHtB/B/7Q=="
+      "version": "1.4.24",
+      "resolved": "https://registry.npmjs.org/@bsv/sdk/-/sdk-1.4.24.tgz",
+      "integrity": "sha512-3f3hSukko9dtCgF87HCUvA1mSLWUdOGhFvkuqQWTD1Wxcb2Kr1C8onjsJs/FqS5bdu7Ks6Dls+eaVtxU7bnDxA=="
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.5.1",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
   },
   "dependencies": {
     "@bsv/gasp": "^1.1.0",
-    "@bsv/sdk": "^1.4.18",
+    "@bsv/sdk": "^1.4.24",
     "knex": "^3.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bsv/overlay",
-  "version": "0.1.28",
+  "version": "0.2.0",
   "type": "module",
   "description": "BSV Blockchain Overlay Services Engine",
   "main": "dist/cjs/mod.js",

--- a/src/Engine.ts
+++ b/src/Engine.ts
@@ -47,7 +47,7 @@ export class Engine {
    * @param {OverlayBroadcastFacilitator} overlayBroadcastFacilitator - Facilitator for propagation to other Overlay Services.
    * @param {typeof console} logger - The place where log entries are written.
    */
-  constructor(
+  constructor (
     public managers: { [key: string]: TopicManager },
     public lookupServices: { [key: string]: LookupService },
     public storage: Storage,
@@ -76,14 +76,14 @@ export class Engine {
       if (managerName === 'tm_ship' && this.shipTrackers !== undefined && this.syncConfiguration[managerName] !== false) {
         // Combine tm_ship trackers with preexisting entries if any
         const combinedSet = new Set([
-          ...(Array.isArray(this.syncConfiguration[managerName]) ? this.syncConfiguration[managerName] as string[] : []),
+          ...(Array.isArray(this.syncConfiguration[managerName]) ? this.syncConfiguration[managerName] : []),
           ...this.shipTrackers
         ])
         this.syncConfiguration[managerName] = Array.from(combinedSet)
       } else if (managerName === 'tm_slap' && this.slapTrackers !== undefined && this.syncConfiguration[managerName] !== false) {
         // Combine tm_slap trackers with preexisting entries if any
         const combinedSet = new Set([
-          ...(Array.isArray(this.syncConfiguration[managerName]) ? this.syncConfiguration[managerName] as string[] : []),
+          ...(Array.isArray(this.syncConfiguration[managerName]) ? this.syncConfiguration[managerName] : []),
           ...this.slapTrackers
         ])
         this.syncConfiguration[managerName] = Array.from(combinedSet)
@@ -97,13 +97,13 @@ export class Engine {
   }
 
   // Helper functions for logging timings
-  private startTime(label: string): void {
+  private startTime (label: string): void {
     if (this.logTime) {
       this.logger.time(`${this.logPrefix} ${label}`)
     }
   }
 
-  private endTime(label: string): void {
+  private endTime (label: string): void {
     if (this.logTime) {
       this.logger.timeEnd(`${this.logPrefix} ${label}`)
     }
@@ -114,12 +114,12 @@ export class Engine {
    * @param {TaggedBEEF} taggedBEEF - The transaction to process
    * @param {function(STEAK): void} [onSTEAKReady] - Optional callback function invoked when the STEAK is ready.
    * @param {string} mode — Indicates the submission behavior, whether historical or current. Historical transactions are not broadcast or propagated.
-   * 
+   *
    * The optional callback function should be used to get STEAK when ready, and avoid waiting for broadcast and transaction propagation to complete.
-   * 
+   *
    * @returns {Promise<STEAK>} The submitted transaction execution acknowledgement
    */
-  async submit(taggedBEEF: TaggedBEEF, onSteakReady?: (steak: STEAK) => void, mode: 'historical-tx' | 'current-tx' = 'current-tx'): Promise<STEAK> {
+  async submit (taggedBEEF: TaggedBEEF, onSteakReady?: (steak: STEAK) => void, mode: 'historical-tx' | 'current-tx' = 'current-tx'): Promise<STEAK> {
     for (const t of taggedBEEF.topics) {
       if (this.managers[t] === undefined || this.managers[t] === null) {
         throw new Error(`This server does not support this topic: ${t}`)
@@ -244,7 +244,7 @@ export class Engine {
 
       const outputsToMarkStale: Array<{
         txid: string
-        previousOutputIndex: number,
+        previousOutputIndex: number
         inputIndex: number
       }> = []
 
@@ -262,12 +262,12 @@ export class Engine {
 
       // For each of the previous UTXOs for this topic, if the UTXO was not included in the list of UTXOs identified for retention, then it will be marked as stale.
       for (const inputIndex of previousCoins) {
-        const previousTXID = tx.inputs[inputIndex].sourceTXID || tx.inputs[inputIndex].sourceTransaction?.id('hex') as string
+        const previousTXID = tx.inputs[inputIndex].sourceTXID || tx.inputs[inputIndex].sourceTransaction?.id('hex')
         const previousOutputIndex = tx.inputs[inputIndex].sourceOutputIndex
         if (!admissibleOutputs.coinsToRetain.includes(inputIndex)) {
           outputsToMarkStale.push({
             txid: previousTXID,
-            previousOutputIndex: previousOutputIndex,
+            previousOutputIndex,
             inputIndex
           })
         } else {
@@ -299,7 +299,7 @@ export class Engine {
           txid,
           outputIndex,
           outputScript: tx.outputs[outputIndex].lockingScript.toBinary(),
-          satoshis: tx.outputs[outputIndex].satoshis as number,
+          satoshis: tx.outputs[outputIndex].satoshis,
           topic,
           spent: false,
           beef: taggedBEEF.beef,
@@ -376,7 +376,7 @@ export class Engine {
    * @param LookupQuestion — The question to ask the Overlay Services Engine
    * @returns The answer to the question
    */
-  async lookup(lookupQuestion: LookupQuestion): Promise<LookupAnswer> {
+  async lookup (lookupQuestion: LookupQuestion): Promise<LookupAnswer> {
     // Validate a lookup service for the provider is found
     const lookupService = this.lookupServices[lookupQuestion.service]
     if (lookupService === undefined || lookupService === null) throw new Error(`Lookup service not found for provider: ${lookupQuestion.service} `)
@@ -417,7 +417,7 @@ export class Engine {
   }
 
   /**
-   * Ensures alignment between the current SHIP/SLAP advertisements and the 
+   * Ensures alignment between the current SHIP/SLAP advertisements and the
    * configured Topic Managers and Lookup Services in the engine.
    *
    * This method performs the following actions:
@@ -435,7 +435,7 @@ export class Engine {
    * @throws Will throw an error if there are issues during the advertisement synchronization process.
    * @returns {Promise<void>} A promise that resolves when the synchronization process is complete.
    */
-  async syncAdvertisements(): Promise<void> {
+  async syncAdvertisements (): Promise<void> {
     if (
       this.advertiser === undefined ||
       typeof this.hostingURL !== 'string' ||
@@ -501,7 +501,7 @@ export class Engine {
    *
    * @throws Error if the overlay service engine is not configured for topical synchronization.
    */
-  async startGASPSync(): Promise<void> {
+  async startGASPSync (): Promise<void> {
     if (this.syncConfiguration === undefined) {
       throw new Error('Overlay Service Engine not configured for topical synchronization!')
     }
@@ -595,7 +595,7 @@ export class Engine {
    * @param topic - The topic for which UTXOs are being requested.
    * @returns A promise that resolves to a GASPInitialResponse containing the list of UTXOs and the provided min block height.
    */
-  async provideForeignSyncResponse(initialRequest: GASPInitialRequest, topic: string): Promise<GASPInitialResponse> {
+  async provideForeignSyncResponse (initialRequest: GASPInitialRequest, topic: string): Promise<GASPInitialResponse> {
     const UTXOs = await this.storage.findUTXOsForTopic(topic, initialRequest.since)
 
     return {
@@ -618,7 +618,7 @@ export class Engine {
    * @returns A promise that resolves to a GASPNode containing the raw transaction and other optional data.
    * @throws An error if no output is found for the given transaction ID and output index.
    */
-  async provideForeignGASPNode(graphID: string, txid: string, outputIndex: number): Promise<GASPNode> {
+  async provideForeignGASPNode (graphID: string, txid: string, outputIndex: number): Promise<GASPNode> {
     const hydrator = async (output: Output | null): Promise<GASPNode> => {
       if (output?.beef === undefined) {
         throw new Error('No matching output found!')
@@ -696,7 +696,7 @@ export class Engine {
    *
    * @returns {Promise<Output | undefined>} - A promise that resolves to the output history if found, or undefined if not.
    */
-  async getUTXOHistory(
+  async getUTXOHistory (
     output: Output,
     historySelector?: ((beef: number[], outputIndex: number, currentDepth: number) => Promise<boolean>) | number,
     currentDepth = 0
@@ -777,7 +777,7 @@ export class Engine {
    * @param output - The UTXO to be deleted.
    * @returns {Promise<void>} - A promise that resolves when the deletion process is complete.
    */
-  private async deleteUTXODeep(output: Output): Promise<void> {
+  private async deleteUTXODeep (output: Output): Promise<void> {
     try {
       // Delete the current output IFF there are no references to it
       if (output.consumedBy.length === 0) {
@@ -833,7 +833,7 @@ export class Engine {
    * @param txid BE hex string double hash of transaction proven by proof.
    * @param proof for txid
    */
-  private updateInputProofs(tx: Transaction, txid: string, proof: MerklePath): void {
+  private updateInputProofs (tx: Transaction, txid: string, proof: MerklePath): void {
     if (tx.merklePath !== undefined) {
       // Update the merkle path to handle potential reorgs
       tx.merklePath = proof
@@ -844,7 +844,7 @@ export class Engine {
     } else {
       for (const input of tx.inputs) {
         // All inputs must have sourceTransactions
-        const stx = input.sourceTransaction!
+        const stx = input.sourceTransaction
         this.updateInputProofs(stx, txid, proof)
       }
     }
@@ -857,7 +857,7 @@ export class Engine {
    * @param txid - The txid for which proof is a valid merkle path.
    * @param proof - The merklePath proving txid is a mined transaction hash
    */
-  private async updateMerkleProof(output: Output, txid: string, proof: MerklePath): Promise<void> {
+  private async updateMerkleProof (output: Output, txid: string, proof: MerklePath): Promise<void> {
     if (output.beef === undefined) {
       throw new Error('Output must have associated transaction BEEF!')
     }
@@ -891,7 +891,7 @@ export class Engine {
    * @param proof - Merkle proof containing the Merkle path and other relevant data to verify the transaction.
    * @param blockHeight - The block height associated with the incoming merkle proof.
    */
-  async handleNewMerkleProof(txid: string, proof: MerklePath, blockHeight?: number): Promise<void> {
+  async handleNewMerkleProof (txid: string, proof: MerklePath, blockHeight?: number): Promise<void> {
     const outputs = await this.storage.findOutputsForTransaction(txid, true)
 
     if (outputs === undefined || outputs.length === 0) {
@@ -914,21 +914,21 @@ export class Engine {
    * @public
    * @returns {Promise<Record<string, { name: string; shortDescription: string; iconURL?: string; version?: string; informationURL?: string; }>>} - Supported topic managers and their metadata
    */
-  async listTopicManagers(): Promise<Record<string, {
-    name: string;
-    shortDescription: string;
-    iconURL?: string;
-    version?: string;
-    informationURL?: string;
+  async listTopicManagers (): Promise<Record<string, {
+    name: string
+    shortDescription: string
+    iconURL?: string
+    version?: string
+    informationURL?: string
   }>> {
-    let result: Record<string, {
-      name: string;
-      shortDescription: string;
-      iconURL?: string;
-      version?: string;
-      informationURL?: string;
+    const result: Record<string, {
+      name: string
+      shortDescription: string
+      iconURL?: string
+      version?: string
+      informationURL?: string
     }> = {}
-    for (let t in this.managers) {
+    for (const t in this.managers) {
       try {
         result[t] = await this.managers[t].getMetaData()
       } catch (e) {
@@ -947,21 +947,21 @@ export class Engine {
    * @public
    * @returns {Promise<Record<string, { name: string; shortDescription: string; iconURL?: string; version?: string; informationURL?: string; }>>} - Supported lookup services and their metadata
    */
-  async listLookupServiceProviders(): Promise<Record<string, {
-    name: string;
-    shortDescription: string;
-    iconURL?: string;
-    version?: string;
-    informationURL?: string;
+  async listLookupServiceProviders (): Promise<Record<string, {
+    name: string
+    shortDescription: string
+    iconURL?: string
+    version?: string
+    informationURL?: string
   }>> {
-    let result: Record<string, {
-      name: string;
-      shortDescription: string;
-      iconURL?: string;
-      version?: string;
-      informationURL?: string;
+    const result: Record<string, {
+      name: string
+      shortDescription: string
+      iconURL?: string
+      version?: string
+      informationURL?: string
     }> = {}
-    for (let ls in this.lookupServices) {
+    for (const ls in this.lookupServices) {
       try {
         result[ls] = await this.lookupServices[ls].getMetaData()
       } catch (e) {
@@ -980,7 +980,7 @@ export class Engine {
    * @public
    * @returns {Promise<string>} - the documentation for the topic manager
    */
-  async getDocumentationForTopicManager(manager: any): Promise<string> {
+  async getDocumentationForTopicManager (manager: any): Promise<string> {
     const documentation = await this.managers[manager]?.getDocumentation?.()
     return documentation !== undefined ? documentation : 'No documentation found!'
   }
@@ -990,7 +990,7 @@ export class Engine {
    * @public
    * @returns {Promise<string>} -  the documentation for the lookup service
    */
-  async getDocumentationForLookupServiceProvider(provider: any): Promise<string> {
+  async getDocumentationForLookupServiceProvider (provider: any): Promise<string> {
     const documentation = await this.lookupServices[provider]?.getDocumentation?.()
     return documentation !== undefined ? documentation : 'No documentation found!'
   }
@@ -1005,12 +1005,12 @@ export class Engine {
    * @param url - The URL string to validate
    * @returns {boolean} - Returns `false` if the URL violates any of the conditions `true` otherwise
    */
-  private isValidUrl(url: string): boolean {
+  private isValidUrl (url: string): boolean {
     try {
       const parsedUrl = new URL(url)
 
       // Disallow http:
-      if (parsedUrl.protocol === "http:") {
+      if (parsedUrl.protocol === 'http:') {
         return false
       }
 
@@ -1026,9 +1026,9 @@ export class Engine {
       const nonRoutableIpv4Patterns = [
         /^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/, // Loopback IPs
         /^10\.\d{1,3}\.\d{1,3}\.\d{1,3}$/, // 10.x.x.x private IPs
-        /^192\.168\.\d{1,3}\.\d{1,3}$/,    // 192.168.x.x private IPs
+        /^192\.168\.\d{1,3}\.\d{1,3}$/, // 192.168.x.x private IPs
         /^172\.(1[6-9]|2[0-9]|3[0-1])\.\d{1,3}\.\d{1,3}$/, // 172.16.x.x to 172.31.x.x private IPs
-        /^0\.0\.0\.0$/                      // Non-routable address
+        /^0\.0\.0\.0$/ // Non-routable address
       ]
 
       // Check for IPv4 matches
@@ -1037,7 +1037,7 @@ export class Engine {
       }
 
       // Check for non-routable IPv6 addresses explicitly
-      if (ipAddress === "[::1]") {
+      if (ipAddress === '[::1]') {
         return false
       }
 

--- a/src/GASP/OverlayGASPRemote.ts
+++ b/src/GASP/OverlayGASPRemote.ts
@@ -1,14 +1,14 @@
-import { GASPInitialReply, GASPInitialRequest, GASPInitialResponse, GASPNode, GASPNodeResponse, GASPRemote } from "@bsv/gasp"
+import { GASPInitialReply, GASPInitialRequest, GASPInitialResponse, GASPNode, GASPNodeResponse, GASPRemote } from '@bsv/gasp'
 
 export class OverlayGASPRemote implements GASPRemote {
-  constructor(public endpointURL: string, public topic: string) { }
+  constructor (public endpointURL: string, public topic: string) { }
 
   /**
    * Given an outgoing initial request, sends the request to the foreign instance and obtains their initial response.
    * @param request
    * @returns
    */
-  async getInitialResponse(request: GASPInitialRequest): Promise<GASPInitialResponse> {
+  async getInitialResponse (request: GASPInitialRequest): Promise<GASPInitialResponse> {
     // Send out an HTTP request to the URL (current host for topic)
     // Include the topic in the request
     // Parse out response and return correct format
@@ -50,7 +50,7 @@ export class OverlayGASPRemote implements GASPRemote {
    * @param metadata
    * @returns
    */
-  async requestNode(graphID: string, txid: string, outputIndex: number, metadata: boolean): Promise<GASPNode> {
+  async requestNode (graphID: string, txid: string, outputIndex: number, metadata: boolean): Promise<GASPNode> {
     // Send an HTTP request with the provided info and get back a gaspNode
     const url = `${this.endpointURL}/requestForeignGASPNode`
     const body = {
@@ -95,13 +95,13 @@ export class OverlayGASPRemote implements GASPRemote {
   // ---- Now optional methods ----
 
   // When are only syncing to them
-  async getInitialReply(response: GASPInitialResponse): Promise<GASPInitialReply> {
+  async getInitialReply (response: GASPInitialResponse): Promise<GASPInitialReply> {
     throw new Error('Function not supported!')
   }
 
   // Only used when supporting bidirectional sync.
   // Overlay services does not support this.
-  async submitNode(node: GASPNode): Promise<void | GASPNodeResponse> {
+  async submitNode (node: GASPNode): Promise<void | GASPNodeResponse> {
     throw new Error('Node submission not supported!')
   }
 }

--- a/src/LookupService.ts
+++ b/src/LookupService.ts
@@ -17,7 +17,7 @@ export type OutputAdmittedByTopic =
     outputIndex: number // index of admitted output
     topic: string // topic into which it was admitted
     satoshis: number // value of the output
-    outputScript: Script // locking script of the output
+    lockingScript: Script // script in this output
   }
   | { // «whole-tx» mode
     mode: 'whole-tx'

--- a/src/LookupService.ts
+++ b/src/LookupService.ts
@@ -1,68 +1,131 @@
 import { LookupFormula } from './LookupFormula.js'
-import { LookupQuestion, LookupAnswer, Script } from '@bsv/sdk'
+import { Script, LookupQuestion, LookupAnswer } from '@bsv/sdk'
 
-/**
- * Defines a Lookup Service interface to be implemented for specific use-cases
- */
+/* ---------------------------------------------------------------------------
+ *  Modes a Lookup Service may request from the Overlay Services Engine
+ * -------------------------------------------------------------------------- */
+export type AdmissionMode = 'locking-script' | 'whole-tx'
+export type SpendNotificationMode = 'none' | 'txid' | 'script' | 'whole-tx'
+
+/* ---------------------------------------------------------------------------
+ *  Admission-Notification payloads
+ * -------------------------------------------------------------------------- */
+export type OutputAdmittedByTopic =
+  | { // «locking-script» mode
+    mode: 'locking-script'
+    txid: string // ID of the *admitted* transaction
+    outputIndex: number // index of admitted output
+    topic: string // topic into which it was admitted
+    satoshis: number // value of the output
+    outputScript: Script // locking script of the output
+  }
+  | { // «whole-tx» mode
+    mode: 'whole-tx'
+    atomicBEEF: number[] // whole transaction (Atomic BEEF)
+    outputIndex: number
+    topic: string
+  }
+
+/* ---------------------------------------------------------------------------
+ *  Spend-Notification payloads
+ * -------------------------------------------------------------------------- */
+export type OutputSpent =
+  | { // «none»      – “it was spent”
+    mode: 'none'
+    txid: string
+    outputIndex: number
+    topic: string
+  }
+  | { // «txid»      – pointer only
+    mode: 'txid'
+    txid: string
+    outputIndex: number
+    topic: string
+    spendingTxid: string
+  }
+  | { // «script»    – granular input data
+    mode: 'script'
+    txid: string
+    outputIndex: number
+    topic: string
+    spendingTxid: string
+    inputIndex: number
+    unlockingScript: Script
+    sequenceNumber: number
+  }
+  | { // «whole-tx»  – full spending TX
+    mode: 'whole-tx'
+    txid: string
+    outputIndex: number
+    topic: string
+    spendingAtomicBEEF: number[]
+  }
+
+/* ---------------------------------------------------------------------------
+ *  Metadata structure returned by getMetaData()
+ * -------------------------------------------------------------------------- */
+export interface LookupServiceMetaData {
+  name: string
+  shortDescription: string
+  iconURL?: string
+  version?: string
+  informationURL?: string
+}
+
+/* ---------------------------------------------------------------------------
+ *  Lookup Service Interface
+ * -------------------------------------------------------------------------- */
 export interface LookupService {
+  /* -------------------------------------------------------------------------
+   *  REQUIRED static declarations
+   * ----------------------------------------------------------------------- */
+  readonly admissionMode: AdmissionMode
+  readonly spendNotificationMode: SpendNotificationMode
+
+  /* -------------------------------------------------------------------------
+   *  REQUIRED lifecycle hooks
+   * ----------------------------------------------------------------------- */
+  /**
+   * Invoked when a Topic Manager admits a new UTXO.
+   * The payload shape depends on this.admissionMode.
+   */
+  outputAdmittedByTopic: (payload: OutputAdmittedByTopic) => Promise<void> | void
 
   /**
-   * Process the event when a new UTXO is let into a topic
-   * @param txid - The transaction ID (TXID) of the transaction where the new UTXO resides.
-   * @param outputIndex - The index of the transaction output (UTXO) within the transaction.
-   * @param outputScript - The script associated with the transaction output.
-   * @param topic - The topic to which the new UTXO is being added.
-   * @returns A promise that resolves when the processing of the new UTXO is complete.
+   * Invoked when a previously-admitted UTXO is spent.
+   * The payload shape depends on this.spendNotificationMode.
    */
-  outputAdded?: (txid: string, outputIndex: number, outputScript: Script, topic: string) => Promise<void>
+  outputSpent?: (payload: OutputSpent) => Promise<void> | void
 
   /**
-   * Processes the spend event for a UTXO.
-   *
-   * @param txid - The transaction ID of the spent UTXO.
-   * @param outputIndex - The index of the transaction output that was spent.
-   * @param topic - The topic from which the UTXO was spent.
-   *
-   * @returns A promise that resolves when processing is complete.
+   * Called when a Topic Manager decides that **historical retention** of the
+   * specified UTXO is no longer required.
    */
-  outputSpent?: (txid: string, outputIndex: number, topic: string) => Promise<void>
+  outputNoLongerRetainedInHistory?: (
+    txid: string,
+    outputIndex: number,
+    topic: string
+  ) => Promise<void> | void
 
   /**
-   * Processes the deletion event for a UTXO.
-   *
-   * @param txid - The transaction ID of the deleted UTXO.
-   * @param outputIndex - The index of the transaction output that was deleted.
-   * @param topic - The topic from which the UTXO was deleted.
-   *
-   * @returns A promise that resolves when processing is complete.
+   * LEGAL EVICTION:
+   * Permanently remove the referenced UTXO from all indices maintained by the
+   * Lookup Service.  After eviction the service MUST NOT reference the output
+   * in any future lookup answer.
    */
-  outputDeleted?: (txid: string, outputIndex: number, topic: string) => Promise<void>
+  outputEvicted: (
+    txid: string,
+    outputIndex: number
+  ) => Promise<void> | void
 
-  /**
-   * Queries the lookup service for information
-   * @param question — The question to be answered by the lookup service
-   * @returns — The Lookup Answer or Lookup Formula used to answer the question
-   */
+  /* -------------------------------------------------------------------------
+   *  Query API
+   * ----------------------------------------------------------------------- */
   lookup: (question: LookupQuestion) => Promise<LookupAnswer | LookupFormula>
 
-  /**
-   * Returns a Markdown-formatted documentation string for the lookup service.
-   *
-   * @returns A promise that resolves to a documentation string.
-   */
+  /* -------------------------------------------------------------------------
+   *  Documentation helpers
+   * ----------------------------------------------------------------------- */
   getDocumentation: () => Promise<string>
-
-  /**
-   * Returns a metadata object that can be used to identify the lookup service.
-   *
-   * @returns A promise that resolves to a metadata object containing the name, short description,
-   *          and optional properties such as icon URL, version, and information URL.
-   */
-  getMetaData: () => Promise<{
-    name: string
-    shortDescription: string
-    iconURL?: string
-    version?: string
-    informationURL?: string
-  }>
+  getMetaData: () => Promise<LookupServiceMetaData>
 }

--- a/src/Output.ts
+++ b/src/Output.ts
@@ -1,7 +1,7 @@
 /**
  * Represents an output to be tracked by the Overlay Services Engine
  */
-export type Output = {
+export interface Output {
   /** TXID of the output */
   txid: string
   /** index of the output */

--- a/src/__tests/Engine.test.ts
+++ b/src/__tests/Engine.test.ts
@@ -25,7 +25,7 @@ const mockOutput: Output = {
   outputIndex: 0,
   outputScript: exampleTX.outputs[0].lockingScript.toBinary(),
   topic: 'hello',
-  satoshis: exampleTX.outputs[0].satoshis as number,
+  satoshis: exampleTX.outputs[0].satoshis,
   beef: exampleBeef,
   spent: false,
   outputsConsumed: [],
@@ -33,20 +33,19 @@ const mockOutput: Output = {
 }
 
 const invalidHostingUrls = [
-  "http://example.com",               // Invalid: http
-  "https://localhost:3000",           // Invalid: localhost
-  "https://192.168.1.1",              // Invalid: internal private IP
-  "https://127.0.0.1",                // Invalid: loopback IP
-  "https://0.0.0.0",                  // Invalid: non-routable IP
-  "http://172.16.0.1",                // Invalid: private IP
-  "[::1]"
+  'http://example.com', // Invalid: http
+  'https://localhost:3000', // Invalid: localhost
+  'https://192.168.1.1', // Invalid: internal private IP
+  'https://127.0.0.1', // Invalid: loopback IP
+  'https://0.0.0.0', // Invalid: non-routable IP
+  'http://172.16.0.1', // Invalid: private IP
+  '[::1]'
 ]
 
-
 const validHostingUrls = [
-  "https://example.com",              // Valid: public URL
-  "https://8.8.8.8",                  // Valid: public routable IP
-  "https://255.255.255.255",          // Valid: public routable IP
+  'https://example.com', // Valid: public URL
+  'https://8.8.8.8', // Valid: public routable IP
+  'https://255.255.255.255' // Valid: public routable IP
 ]
 
 const mockAdvertiser: Advertiser = {
@@ -107,7 +106,7 @@ describe('BSV Overlay Services Engine', () => {
         undefined
       )
 
-      engine.submit = jest.fn(async (taggedBEEF: TaggedBEEF, onSteakReady: any, mode?: string) => ({ 'tm_helloworld': { outputsToAdmit: [], coinsToRetain: [], coinsRemoved: [] } } as STEAK))
+      engine.submit = jest.fn(async (taggedBEEF: TaggedBEEF, onSteakReady: any, mode?: string) => ({ tm_helloworld: { outputsToAdmit: [], coinsToRetain: [], coinsRemoved: [] } } as STEAK))
 
       // Call the method that would normally trigger syncAdvertisements
       const result = await engine.syncAdvertisements()
@@ -128,8 +127,8 @@ describe('BSV Overlay Services Engine', () => {
       parseAdvertisement: jest.fn().mockReturnValue({
         protocol: 'SHIP',
         topicOrServiceName: 'mock-topic',
-        timestamp: Date.now(),
-      }),
+        timestamp: Date.now()
+      })
     }
 
     for (const url of validHostingUrls) {
@@ -147,7 +146,7 @@ describe('BSV Overlay Services Engine', () => {
       )
 
       // Call the method that would normally trigger syncAdvertisements
-      engine.submit = jest.fn(async (taggedBEEF: TaggedBEEF, onSteakReady: any, mode?: string) => ({ 'tm_helloworld': { outputsToAdmit: [], coinsToRetain: [], coinsRemoved: [] } } as STEAK))
+      engine.submit = jest.fn(async (taggedBEEF: TaggedBEEF, onSteakReady: any, mode?: string) => ({ tm_helloworld: { outputsToAdmit: [], coinsToRetain: [], coinsRemoved: [] } } as STEAK))
       const result = await engine.syncAdvertisements()
       expect(engine.submit).toHaveBeenCalled()
 
@@ -240,7 +239,7 @@ describe('BSV Overlay Services Engine', () => {
       outputIndex: 0,
       outputScript: exampleTX.outputs[0].lockingScript.toBinary(),
       topic: 'hello',
-      satoshis: exampleTX.outputs[0].satoshis as number,
+      satoshis: exampleTX.outputs[0].satoshis,
       beef: exampleBeef,
       spent: false,
       outputsConsumed: [],
@@ -305,7 +304,7 @@ describe('BSV Overlay Services Engine', () => {
           outputIndex,
           outputScript: tx.outputs[outputIndex].lockingScript.toBinary(),
           topic: 'hello',
-          satoshis: tx.outputs[outputIndex].satoshis as number,
+          satoshis: tx.outputs[outputIndex].satoshis,
           beef: tx.toBEEF(),
           spent: false,
           outputsConsumed: [],

--- a/src/storage/Storage.ts
+++ b/src/storage/Storage.ts
@@ -78,7 +78,6 @@ export interface Storage {
    */
   updateTransactionBEEF: (txid: string, beef: number[]) => Promise<void>
 
-
   /**
    * Updates the block height on an output
    * @param txid — TXID of the output to update

--- a/src/storage/knex/KnexStorage.ts
+++ b/src/storage/knex/KnexStorage.ts
@@ -5,11 +5,11 @@ import type { Output } from '../../Output.js'
 export class KnexStorage implements Storage {
   knex: Knex
 
-  constructor(knex: Knex) {
+  constructor (knex: Knex) {
     this.knex = knex
   }
 
-  async findOutput(txid: string, outputIndex: number, topic?: string, spent?: boolean, includeBEEF: boolean = false): Promise<Output | null> {
+  async findOutput (txid: string, outputIndex: number, topic?: string, spent?: boolean, includeBEEF: boolean = false): Promise<Output | null> {
     const search: {
       'outputs.txid': string
       'outputs.outputIndex': number
@@ -59,7 +59,7 @@ export class KnexStorage implements Storage {
     }
   }
 
-  async findOutputsForTransaction(txid: string, includeBEEF: boolean = false): Promise<Output[]> {
+  async findOutputsForTransaction (txid: string, includeBEEF: boolean = false): Promise<Output[]> {
     // Base query to get outputs
     const query = this.knex('outputs').where({ 'outputs.txid': txid })
 
@@ -97,7 +97,7 @@ export class KnexStorage implements Storage {
     }))
   }
 
-  async findUTXOsForTopic(topic: string, since?: number, includeBEEF: boolean = false): Promise<Output[]> {
+  async findUTXOsForTopic (topic: string, since?: number, includeBEEF: boolean = false): Promise<Output[]> {
     // Base query to get outputs
     const query = this.knex('outputs').where({ 'outputs.topic': topic, 'outputs.spent': false })
 
@@ -141,7 +141,7 @@ export class KnexStorage implements Storage {
     }))
   }
 
-  async deleteOutput(txid: string, outputIndex: number, topic: string): Promise<void> {
+  async deleteOutput (txid: string, outputIndex: number, topic: string): Promise<void> {
     await this.knex.transaction(async trx => {
       // Delete the specific output
       await trx('outputs').where({ txid, outputIndex }).del()
@@ -156,7 +156,7 @@ export class KnexStorage implements Storage {
     })
   }
 
-  async insertOutput(output: Output): Promise<void> {
+  async insertOutput (output: Output): Promise<void> {
     const insertPromises = [this.knex('outputs').insert({
       txid: output.txid,
       outputIndex: Number(output.outputIndex),
@@ -181,7 +181,7 @@ export class KnexStorage implements Storage {
     })
   }
 
-  async markUTXOAsSpent(txid: string, outputIndex: number, topic?: string): Promise<void> {
+  async markUTXOAsSpent (txid: string, outputIndex: number, topic?: string): Promise<void> {
     await this.knex('outputs').where({
       txid,
       outputIndex,
@@ -189,7 +189,7 @@ export class KnexStorage implements Storage {
     }).update('spent', true)
   }
 
-  async updateConsumedBy(txid: string, outputIndex: number, topic: string, consumedBy: Array<{ txid: string, outputIndex: number }>): Promise<void> {
+  async updateConsumedBy (txid: string, outputIndex: number, topic: string, consumedBy: Array<{ txid: string, outputIndex: number }>): Promise<void> {
     await this.knex('outputs').where({
       txid,
       outputIndex,
@@ -197,13 +197,13 @@ export class KnexStorage implements Storage {
     }).update('consumedBy', JSON.stringify(consumedBy))
   }
 
-  async updateTransactionBEEF(txid: string, beef: number[]): Promise<void> {
+  async updateTransactionBEEF (txid: string, beef: number[]): Promise<void> {
     await this.knex('transactions').where({
       txid
     }).update('beef', Buffer.from(beef))
   }
 
-  async updateOutputBlockHeight(txid: string, outputIndex: number, topic: string, blockHeight: number): Promise<void> {
+  async updateOutputBlockHeight (txid: string, outputIndex: number, topic: string, blockHeight: number): Promise<void> {
     await this.knex('outputs').where({
       txid,
       outputIndex,
@@ -211,14 +211,14 @@ export class KnexStorage implements Storage {
     }).update('blockHeight', blockHeight)
   }
 
-  async insertAppliedTransaction(tx: { txid: string, topic: string }): Promise<void> {
+  async insertAppliedTransaction (tx: { txid: string, topic: string }): Promise<void> {
     await this.knex('applied_transactions').insert({
       txid: tx.txid,
       topic: tx.topic
     })
   }
 
-  async doesAppliedTransactionExist(tx: { txid: string, topic: string }): Promise<boolean> {
+  async doesAppliedTransactionExist (tx: { txid: string, topic: string }): Promise<boolean> {
     const result = await this.knex('applied_transactions')
       .where({ txid: tx.txid, topic: tx.topic })
       .select(this.knex.raw('1'))

--- a/src/storage/knex/all-migrations.ts
+++ b/src/storage/knex/all-migrations.ts
@@ -7,7 +7,7 @@ import { up as addedIndexesUp, down as addedIndexesDown } from './migrations/202
 /**
  * An array of all migrations, in order.
  */
-type Migration = {
+interface Migration {
   up: (knex: Knex) => Promise<void>
   down: (knex: Knex) => Promise<void>
 }

--- a/src/storage/knex/migrations/2024-05-18-001-initial.ts
+++ b/src/storage/knex/migrations/2024-05-18-001-initial.ts
@@ -1,6 +1,6 @@
 import type { Knex } from 'knex'
 
-export async function up(knex: Knex): Promise<void> {
+export async function up (knex: Knex): Promise<void> {
   await knex.schema.createTable('outputs', table => {
     table.increments()
     table.string('txid', 64)
@@ -24,7 +24,7 @@ export async function up(knex: Knex): Promise<void> {
   })
 }
 
-export async function down(knex: Knex): Promise<void> {
+export async function down (knex: Knex): Promise<void> {
   await knex.schema.dropTable('applied_transactions')
   await knex.schema.dropTable('outputs')
 }

--- a/src/storage/knex/migrations/2024-07-10-001-block-height.ts
+++ b/src/storage/knex/migrations/2024-07-10-001-block-height.ts
@@ -1,13 +1,13 @@
 import type { Knex } from 'knex'
 
-export async function up(knex: Knex): Promise<void> {
+export async function up (knex: Knex): Promise<void> {
   // Add new column for blockHeight associated with outputs
   await knex.schema.table('outputs', table => {
     table.integer('blockHeight').unsigned().nullable()
   })
 }
 
-export async function down(knex: Knex): Promise<void> {
+export async function down (knex: Knex): Promise<void> {
   // Remove the blockHeight column (rollback operation)
   await knex.schema.table('outputs', table => {
     table.dropColumn('blockHeight')

--- a/src/storage/knex/migrations/2024-07-17-001-transactions.ts
+++ b/src/storage/knex/migrations/2024-07-17-001-transactions.ts
@@ -1,6 +1,6 @@
 import type { Knex } from 'knex'
 
-export async function up(knex: Knex): Promise<void> {
+export async function up (knex: Knex): Promise<void> {
   // Create the new transactions table
   await knex.schema.createTable('transactions', table => {
     table.increments()
@@ -22,7 +22,7 @@ export async function up(knex: Knex): Promise<void> {
   })
 }
 
-export async function down(knex: Knex): Promise<void> {
+export async function down (knex: Knex): Promise<void> {
   // Add the beef column back to the outputs table
   await knex.schema.table('outputs', table => {
     table.binary('beef')

--- a/src/storage/knex/migrations/2024-07-18-001-indexes.ts
+++ b/src/storage/knex/migrations/2024-07-18-001-indexes.ts
@@ -1,5 +1,5 @@
 import type { Knex } from 'knex'
-export async function up(knex: Knex): Promise<void> {
+export async function up (knex: Knex): Promise<void> {
   // Add index for applied_transactions table
   await knex.schema.table('applied_transactions', function (table) {
     table.index(['txid', 'topic'], 'idx_applied_transactions_txid_topic')
@@ -14,7 +14,7 @@ export async function up(knex: Knex): Promise<void> {
   })
 }
 
-export async function down(knex: Knex): Promise<void> {
+export async function down (knex: Knex): Promise<void> {
   // Drop index for applied_transactions table
   await knex.schema.table('applied_transactions', function (table) {
     table.dropIndex(['txid', 'topic'], 'idx_applied_transactions_txid_topic')


### PR DESCRIPTION
This is an improved version of the Lookup Service interface. It now supports:
* Legal evictions of outputs
* Specifying what data the engine should provide for new and spent outputs
* Improved naming clarity around historical retention
* All services must now respond to output eviction events, purging relevant data from indices.

This is a **BREAKING** change to Overlay Services. All existing lookup services must be updated when you replace the installed Engine with the new version. It is slated for release as `0.2.0`.