### PR TITLE
Private overlays

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bsv/overlay",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bsv/overlay",
-      "version": "0.3.1",
+      "version": "0.4.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@bsv/gasp": "^1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@bsv/gasp": "^1.1.0",
-        "@bsv/sdk": "^1.6.0",
+        "@bsv/sdk": "^1.6.1",
         "knex": "^3.1.0"
       },
       "devDependencies": {
@@ -497,9 +497,9 @@
       }
     },
     "node_modules/@bsv/sdk": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@bsv/sdk/-/sdk-1.6.0.tgz",
-      "integrity": "sha512-4RpYgiN+pLKohXLaO0p1tnYRJ6UF59ItVsu1qtazHzaawoIOhfxkvbnKvznHQCdcJkGPtT1EFKZFiheqXnt7sQ=="
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@bsv/sdk/-/sdk-1.6.1.tgz",
+      "integrity": "sha512-LDdNkns0fOtD99GMzIUemUSbg/3bJYA4bQBUA7QnxscnHC6Tmrr1toK7sxRxsVrcsU6KIlJzTMHsDk2UGVd3xA=="
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bsv/overlay",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "type": "module",
   "description": "BSV Blockchain Overlay Services Engine",
   "main": "dist/cjs/mod.js",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
   },
   "dependencies": {
     "@bsv/gasp": "^1.1.0",
-    "@bsv/sdk": "^1.6.0",
+    "@bsv/sdk": "^1.6.1",
     "knex": "^3.1.0"
   }
 }

--- a/src/GASP/OverlayGASPStorage.ts
+++ b/src/GASP/OverlayGASPStorage.ts
@@ -1,5 +1,5 @@
 import { GASPNode, GASPNodeResponse, GASPStorage } from '@bsv/gasp'
-import { MerklePath, Transaction } from '@bsv/sdk'
+import { MerklePath, Transaction, Utils } from '@bsv/sdk'
 import { Engine } from '../Engine.js'
 
 /**
@@ -90,7 +90,7 @@ export class OverlayGASPStorage implements GASPStorage {
 
     // Attempt to check if the current transaction is admissible
     parsedTx.merklePath = MerklePath.fromHex(tx.proof)
-    const admittanceResult = await this.engine.managers[this.topic].identifyAdmissibleOutputs(parsedTx.toBEEF(), [])
+    const admittanceResult = await this.engine.managers[this.topic].identifyAdmissibleOutputs(parsedTx.toBEEF(), [], typeof tx.txMetadata === 'string' ? Utils.toArray(tx.txMetadata) : undefined)
 
     if (admittanceResult.outputsToAdmit.includes(tx.outputIndex)) {
       // The transaction is admissible, no further inputs are needed

--- a/src/LookupFormula.ts
+++ b/src/LookupFormula.ts
@@ -23,4 +23,9 @@ export type LookupFormula = Array<{
    * If not provided, no historical information will be included with the Lookup Answer, except that which may incidentally be required to fully anchor the Lookup Answer to the blockchain.
    */
   history?: ((beef: number[], outputIndex: number, currentDepth: number) => Promise<boolean>) | number
+
+  /**
+   * Context for the UTXO, derived from the off-chain values.
+   */
+  context?: number[]
 }>

--- a/src/LookupService.ts
+++ b/src/LookupService.ts
@@ -18,12 +18,14 @@ export type OutputAdmittedByTopic =
     topic: string // topic into which it was admitted
     satoshis: number // value of the output
     lockingScript: Script // script in this output
+    offChainValues?: number[] // off-chain values associated with the output
   }
   | { // «whole-tx» mode
     mode: 'whole-tx'
     atomicBEEF: number[] // whole transaction (Atomic BEEF)
     outputIndex: number
     topic: string
+    offChainValues?: number[]
   }
 
 /* ---------------------------------------------------------------------------
@@ -52,6 +54,7 @@ export type OutputSpent =
     inputIndex: number
     unlockingScript: Script
     sequenceNumber: number
+    offChainValues?: number[]
   }
   | { // «whole-tx»  – full spending TX
     mode: 'whole-tx'
@@ -59,6 +62,7 @@ export type OutputSpent =
     outputIndex: number
     topic: string
     spendingAtomicBEEF: number[]
+    offChainValues?: number[]
   }
 
 /* ---------------------------------------------------------------------------
@@ -121,7 +125,7 @@ export interface LookupService {
   /* -------------------------------------------------------------------------
    *  Query API
    * ----------------------------------------------------------------------- */
-  lookup: (question: LookupQuestion) => Promise<LookupAnswer | LookupFormula>
+  lookup: (question: LookupQuestion) => Promise<LookupFormula>
 
   /* -------------------------------------------------------------------------
    *  Documentation helpers

--- a/src/TopicManager.ts
+++ b/src/TopicManager.ts
@@ -9,13 +9,13 @@ export interface TopicManager {
    * Accepts the transaction in BEEF format and an array of those input indices which spend previously-admitted outputs from the same topic.
    * The transaction's BEEF structure will always contain the transactions associated with previous coins for reference (if any), regardless of whether the current transaction was directly proven.
    */
-  identifyAdmissibleOutputs: (beef: number[], previousCoins: number[]) => Promise<AdmittanceInstructions>
+  identifyAdmissibleOutputs: (beef: number[], previousCoins: number[], offChainValues?: number[]) => Promise<AdmittanceInstructions>
 
   /**
    * Identifies and returns the inputs needed to anchor any topical outputs from this transaction to their associated previous history.
    * @throws - if there are no potentially valid topical outputs in this transaction
    */
-  identifyNeededInputs?: (beef: number[]) => Promise<Array<{ txid: string, outputIndex: number }>>
+  identifyNeededInputs?: (beef: number[], offChainValues?: number[]) => Promise<Array<{ txid: string, outputIndex: number }>>
 
   /**
   * Returns a Markdown-formatted documentation string for the topic manager.

--- a/src/__tests/Engine.test.ts
+++ b/src/__tests/Engine.test.ts
@@ -534,7 +534,7 @@ describe('BSV Overlay Services Engine', () => {
           beef: exampleBeef,
           topics: ['Hello']
         })
-        expect(engine.managers.Hello.identifyAdmissibleOutputs).toHaveBeenCalledWith(exampleBeef, [0])
+        expect(engine.managers.Hello.identifyAdmissibleOutputs).toHaveBeenCalledWith(exampleBeef, [0], undefined)
       })
       describe('When previous UTXOs were retained by the topic manager', () => {
         it('Notifies all lookup services about the output being spent (not deleted, see the comment about this in deleteUTXODeep)', async () => {


### PR DESCRIPTION
* Accept OffChainValues in topic managers
* Drive lookup services with OffChainValues in output admittance and spend notificatiions
* Return Context along with lookup responses

All optional, all backwards compatible. No Storage changes because lookup services store any needed off-chain info in their own data stores.