### PR TITLE
docs: align overlay getting started with current stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ All notable changes to this project will be documented in this file. The format 
 - (Include new features or significant user-visible enhancements here.)
 
 ### Changed
-- (Detail modifications that are non-breaking but relevant to the end-users.)
+- Refreshed the getting-started documentation to align direct `@bsv/overlay` usage with the current `@bsv/sdk`, Overlay Express, LARS, and CARS application workflow.
 
 ### Deprecated
 - (List features that are in the process of being phased out or replaced.)

--- a/README.md
+++ b/README.md
@@ -23,243 +23,123 @@ The Overlay Services Engine enables dynamic tracking and management of UTXO-base
 
 ## Getting Started
 
+### Choose the Right Package
+
+Most application developers should start with the higher-level deployment tools:
+
+- [`@bsv/overlay-express`](https://github.com/bsv-blockchain/overlay-express): opinionated Express wrapper for running overlay nodes with HTTP routes, health checks, storage configuration, SHIP/SLAP discovery, and GASP synchronization.
+- [`@bsv/lars`](https://github.com/bsv-blockchain/lars): local runtime for BSV application projects that use `deployment-info.json`.
+- [`@bsv/cars-cli`](https://github.com/bsv-blockchain/cars-cli): cloud deployment workflow for the same `deployment-info.json` project structure.
+
+Use this package, `@bsv/overlay`, when you need direct control over the Overlay Services Engine itself, such as custom storage, custom broadcasting, or a non-Express host.
+
 ### Installation
 
-You'll usually want to wrap the Engine within an HTTP server. To get set up with Express, create a new project and install everything you'll need:
+For direct engine integration, install the engine with the current BSV TypeScript SDK:
 
 ```
-npm i express body-parser @bsv/sdk @bsv/overlay hello-services knex
+npm i @bsv/overlay @bsv/sdk knex
 ```
 
 ### Basic Usage
 
-In your server's main file, you can set everything up. Create a new Engine to run the overlay services you want, then expose some routes over HTTP. For example:
+Create an `Engine` with topic managers, lookup services, a storage implementation, and a chain tracker. The example below uses minimal in-memory stubs so the shape is clear. Production services should use durable storage, a real chain tracker, and a broadcaster appropriate for the target network.
 
-```js
-const express = require('express')
-const bodyparser = require('body-parser')
-const { Engine, KnexStorage, HelloTopicManager, HelloLookupService, HelloStorageEngine } = require('@bsv/overlay')
-import { WhatsOnChain, NodejsHttpClient, ARC, ArcConfig, MerklePath } from '@bsv/sdk'
-// Populate a Knexfile with your database credentials
-const knex = require('knex')(require('../knexfile.js'))
-const app = express()
-app.use(bodyparser.json({ limit: '1gb', type: 'application/json' }))
+```ts
+import {
+  Engine,
+  type AdmittanceInstructions,
+  type LookupFormula,
+  type LookupQuestion,
+  type Output,
+  type Storage,
+  type TopicManager,
+  type LookupService
+} from '@bsv/overlay'
+
+const topicManager: TopicManager = {
+  async identifyAdmissibleOutputs (): Promise<AdmittanceInstructions> {
+    return {
+      outputsToAdmit: [],
+      coinsToRetain: []
+    }
+  },
+  async getDocumentation () {
+    return 'Admits outputs for the example topic.'
+  },
+  async getMetaData () {
+    return {
+      name: 'Example Topic Manager',
+      shortDescription: 'Example topic manager',
+      iconURL: '',
+      version: '1.0.0',
+      informationURL: ''
+    }
+  }
+}
+
+const lookupService: LookupService = {
+  async outputAdmittedByTopic (): Promise<void> {},
+  async outputSpent (): Promise<void> {},
+  async outputEvicted (): Promise<void> {},
+  async lookup (_question: LookupQuestion): Promise<LookupFormula> {
+    return {
+      type: 'formula',
+      outpoints: []
+    }
+  },
+  async getDocumentation () {
+    return 'Looks up outputs admitted by the example topic.'
+  },
+  async getMetaData () {
+    return {
+      name: 'Example Lookup Service',
+      shortDescription: 'Example lookup service',
+      iconURL: '',
+      version: '1.0.0',
+      informationURL: ''
+    }
+  }
+}
+
+const storage: Storage = {
+  async findOutput (): Promise<Output | null> { return null },
+  async findOutputsForTransaction (): Promise<Output[]> { return [] },
+  async findOutputsForTopic (): Promise<Output[]> { return [] },
+  async findUTXOHistory (): Promise<Output[]> { return [] },
+  async insertOutput (): Promise<void> {},
+  async updateConsumedBy (): Promise<void> {},
+  async updateTransactionBEEF (): Promise<void> {},
+  async deleteOutput (): Promise<void> {},
+  async startGASPSync (): Promise<void> {},
+  async updateLastInteraction (): Promise<void> {},
+  async getLastInteraction (): Promise<Date | null> { return null },
+  async getSyncState (): Promise<unknown> { return undefined },
+  async setSyncState (): Promise<void> {}
+}
 
 const engine = new Engine(
-    {
-      hello: new HelloTopicManager(),
-    },
-    {
-      hello: new HelloLookupService({
-        storageEngine: new HelloStorageEngine({
-          knex
-        })
-      }),
-    },
-    new KnexStorageEngine({
-      knex
-    }),
-    new CombinatorialChainTracker([
-      new WhatsOnChain(
-        NODE_ENV === 'production' ? 'main' : 'test',
-        {
-          httpClient: new NodejsHttpClient(https)
-        })
-    ]),
-    HOSTING_DOMAIN as string,
-    SHIP_TRACKERS,
-    SLAP_TRACKERS,
-    new ARC('https://arc.taal.com', arcConfig)
-  )
+  { tm_example: topicManager },
+  { ls_example: lookupService },
+  storage,
+  'scripts only',
+  'https://example-overlay.example',
+  [],
+  [],
+  undefined,
+  undefined,
+  { tm_example: false }
+)
 
-// This allows the API to be used everywhere when CORS is enforced
-app.use((req, res, next) => {
-  res.header('Access-Control-Allow-Origin', '*')
-  res.header('Access-Control-Allow-Headers', '*')
-  res.header('Access-Control-Allow-Methods', '*')
-  res.header('Access-Control-Expose-Headers', '*')
-  res.header('Access-Control-Allow-Private-Network', 'true')
-  if (req.method === 'OPTIONS') {
-    res.sendStatus(200)
-  } else {
-    next()
-  }
-})
-
-// Serve a static documentstion site, if you have one.
-app.use(express.static('public'))
-
-// List hosted topic managers and lookup services
-app.get(`/listTopicManagers`, async (req, res) => {
-  try {
-    const result = await engine.listTopicManagers()
-    return res.status(200).json(result)
-  } catch (error) {
-    return res.status(400).json({
-      status: 'error',
-      code: error.code,
-      description: error.message
-    })
-  }
-})
-app.get(`/listLookupServiceProviders`, async (req, res) => {
-  try {
-    const result = await engine.listLookupServiceProviders()
-    return res.status(200).json(result)
-  } catch (error) {
-    return res.status(400).json({
-      status: 'error',
-      code: error.code,
-      description: error.message
-    })
-  }
-})
-
-// Host documentation for the services
-app.get(`/getDocumentationForTopicManager`, async (req, res) => {
-  try {
-    const result = await engine.getDocumentationForTopicManger(req.query.manager)
-    return res.status(200).json(result)
-  } catch (error) {
-    return res.status(400).json({
-      status: 'error',
-      code: error.code,
-      description: error.message
-    })
-  }
-})
-app.get(`/getDocumentationForLookupServiceProvider`, async (req, res) => {
-  try {
-    const result = await engine.getDocumentationForLookupServiceProvider(req.query.lookupServices)
-    return res.status(200).json(result)
-  } catch (error) {
-    return res.status(400).json({
-      status: 'error',
-      code: error.code,
-      description: error.message
-    })
-  }
-})
-
-// Submit transactions and facilitate lookup requests
-app.post(`/submit`, async (req, res) => {
-  try {
-    // Parse out the topics and construct the tagged BEEF
-    const topics = JSON.parse(req.headers['x-topics'] as string)
-    const taggedBEEF: TaggedBEEF = {
-      beef: Array.from(req.body as number[]),
-      topics
-    }
-
-    // Using a callback function, we can just return once our steak is ready
-    // instead of having to wait for all the broadcasts to occur.
-    await engine.submit(taggedBEEF, (steak: STEAK) => {
-      return res.status(200).json(steak)
-    })
-  } catch (error) {
-    return res.status(400).json({
-      status: 'error',
-      code: error.code,
-      description: error.message
-    })
-  }
-})
-app.post(`/lookup`, async (req, res) => {
-  try {
-    const result = await engine.lookup(req.body)
-    return res.status(200).json(result)
-  } catch (error) {
-    return res.status(400).json({
-      status: 'error',
-      code: error.code,
-      description: error.message
-    })
-  }
-})
-
-app.post('/arc-ingest', (req, res) => {
-  (async () => {
-    try {
-      const merklePath = MerklePath.fromHex(req.body.merklePath)
-      await engine.handleNewMerkleProof(req.body.txid, merklePath, req.body.blockHeight)
-      return res.status(200).json({ status: 'success', message: 'transaction status updated' })
-    } catch (error) {
-      console.error(error)
-      return res.status(400).json({
-        status: 'error',
-        message: error instanceof Error ? error.message : 'An unknown error occurred'
-      })
-    }
-  })().catch(() => {
-    res.status(500).json({
-      status: 'error',
-      message: 'Unexpected error'
-    })
-  })
-})
-
-app.post('/requestSyncResponse', (req, res) => {
-  (async () => {
-    try {
-      const topic = req.headers['x-bsv-topic'] as string
-      const response = await engine.provideForeignSyncResponse(req.body, topic)
-      return res.status(200).json(response)
-    } catch (error) {
-      console.error(error)
-      return res.status(400).json({
-        status: 'error',
-        message: error instanceof Error ? error.message : 'An unknown error occurred'
-      })
-    }
-  })().catch(() => {
-    res.status(500).json({
-      status: 'error',
-      message: 'Unexpected error'
-    })
-  })
-})
-
-app.post('/requestForeignGASPNode', (req, res) => {
-  (async () => {
-    try {
-      console.log(req.body)
-      const { graphID, txid, outputIndex, metadata } = req.body
-      const response = await engine.provideForeignGASPNode(graphID, txid, outputIndex)
-      return res.status(200).json(response)
-    } catch (error) {
-      console.error(error)
-      return res.status(400).json({
-        status: 'error',
-        message: error instanceof Error ? error.message : 'An unknown error occurred'
-      })
-    }
-  })().catch(() => {
-    res.status(500).json({
-      status: 'error',
-      message: 'Unexpected error'
-    })
-  })
-})
-
-// 404, all other routes are not found.
-app.use((req, res) => {
-  console.log('404', req.url)
-  res.status(404).json({
-    status: 'error',
-    code: 'ERR_ROUTE_NOT_FOUND',
-    description: 'Route not found.'
-  })
-})
-
-// Start your Engines!
-  app.listen(8080, () => {
-    console.log('BSV Overlay Services Engine is listening on port', 8080)
-  })
+const topics = await engine.listTopicManagers()
+const services = await engine.listLookupServiceProviders()
 ```
 
-For more detailed tutorials and examples, check out the [full documentation](#documentation).
+For deployable HTTP examples, use [`@bsv/overlay-express`](https://github.com/bsv-blockchain/overlay-express) and [`overlay-express-examples`](https://github.com/bsv-blockchain/overlay-express-examples). For local and cloud application runtime workflows, use LARS and CARS with the BRC-102 `deployment-info.json` project structure.
 
-The Overlay Services Engine is also richly documented with code-level annotations. This should show up well within editors like VSCode. 
+For lower-level engine examples, check out the [full documentation](#documentation).
+
+The Overlay Services Engine is also richly documented with code-level annotations. This should show up well within editors like VSCode.
 
 <!-- ## Documentation
 
@@ -271,10 +151,10 @@ The Overlay Services Engine is also richly documented with code-level annotation
 - History management and state tracking
 - Lookup Services
 - Storage engine abstractions
-- [WIP] Examples, HTTP wrapper and Docs
-- [WIP] Arc Proof Acquisition
-- [WIP] Distributed Overlay Availability Advertisements
-- [WIP] Federated Transaction Synchronization
+- Examples, HTTP wrapper, and docs through `@bsv/overlay-express`
+- ARC callback handling through overlay hosts
+- Distributed overlay availability advertisements with SHIP and SLAP
+- Federated transaction synchronization with GASP
 
 ## Contribution Guidelines
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,9 +1,5 @@
 # API
 
-[🏠 Home](./README.md) | [📚 API](./API.md) | [💡 Concepts](./concepts/README.md) | [📖 Examples](./examples/README.md) | [⚙️ Internal](./internal/README.md)
-
----
-
 Links: [API](#api), [Interfaces](#interfaces), [Classes](#classes), [Functions](#functions), [Types](#types)
 
 ## Interfaces
@@ -69,6 +65,48 @@ export interface Advertiser {
 
 See also: [Advertisement](#interface-advertisement), [AdvertisementData](#interface-advertisementdata)
 
+<details>
+
+<summary>Interface Advertiser Details</summary>
+
+#### Property createAdvertisements
+
+Creates a new SHIP/SLAP advertisement for a given topic.
+
+```ts
+createAdvertisements: (adsData: AdvertisementData[]) => Promise<TaggedBEEF>
+```
+See also: [AdvertisementData](#interface-advertisementdata)
+
+#### Property findAllAdvertisements
+
+Finds all SHIP/SLAP advertisements.
+
+```ts
+findAllAdvertisements: (protocol: "SHIP" | "SLAP") => Promise<Advertisement[]>
+```
+See also: [Advertisement](#interface-advertisement)
+
+#### Property parseAdvertisement
+
+Parses an output script to extract an advertisement.
+
+```ts
+parseAdvertisement: (outputScript: Script) => Advertisement
+```
+See also: [Advertisement](#interface-advertisement)
+
+#### Property revokeAdvertisements
+
+Revokes an existing advertisement, either SHIP or SLAP.
+
+```ts
+revokeAdvertisements: (advertisements: Advertisement[]) => Promise<TaggedBEEF>
+```
+See also: [Advertisement](#interface-advertisement)
+
+</details>
+
 Links: [API](#api), [Interfaces](#interfaces), [Classes](#classes), [Functions](#functions), [Types](#types)
 
 ---
@@ -82,6 +120,28 @@ export interface AppliedTransaction {
     topic: string;
 }
 ```
+
+<details>
+
+<summary>Interface AppliedTransaction Details</summary>
+
+#### Property topic
+
+Output index of the applied transaction
+
+```ts
+topic: string
+```
+
+#### Property txid
+
+TXID of the applied transaction
+
+```ts
+txid: string
+```
+
+</details>
 
 Links: [API](#api), [Interfaces](#interfaces), [Classes](#classes), [Functions](#functions), [Types](#types)
 
@@ -129,6 +189,52 @@ export interface LookupService {
 
 See also: [AdmissionMode](#type-admissionmode), [LookupFormula](#type-lookupformula), [LookupServiceMetaData](#interface-lookupservicemetadata), [OutputAdmittedByTopic](#type-outputadmittedbytopic), [OutputSpent](#type-outputspent), [SpendNotificationMode](#type-spendnotificationmode)
 
+<details>
+
+<summary>Interface LookupService Details</summary>
+
+#### Property outputAdmittedByTopic
+
+Invoked when a Topic Manager admits a new UTXO.
+The payload shape depends on this.admissionMode.
+
+```ts
+outputAdmittedByTopic: (payload: OutputAdmittedByTopic) => Promise<void> | void
+```
+See also: [OutputAdmittedByTopic](#type-outputadmittedbytopic)
+
+#### Property outputEvicted
+
+LEGAL EVICTION:
+Permanently remove the referenced UTXO from all indices maintained by the
+Lookup Service.  After eviction the service MUST NOT reference the output
+in any future lookup answer.
+
+```ts
+outputEvicted: (txid: string, outputIndex: number) => Promise<void> | void
+```
+
+#### Property outputNoLongerRetainedInHistory
+
+Called when a Topic Manager decides that **historical retention** of the
+specified UTXO is no longer required.
+
+```ts
+outputNoLongerRetainedInHistory?: (txid: string, outputIndex: number, topic: string) => Promise<void> | void
+```
+
+#### Property outputSpent
+
+Invoked when a previously-admitted UTXO is spent.
+The payload shape depends on this.spendNotificationMode.
+
+```ts
+outputSpent?: (payload: OutputSpent) => Promise<void> | void
+```
+See also: [OutputSpent](#type-outputspent)
+
+</details>
+
 Links: [API](#api), [Interfaces](#interfaces), [Classes](#classes), [Functions](#functions), [Types](#types)
 
 ---
@@ -173,6 +279,90 @@ export interface Output {
 }
 ```
 
+<details>
+
+<summary>Interface Output Details</summary>
+
+#### Property beef
+
+The transaction data for the output
+
+```ts
+beef?: number[]
+```
+
+#### Property consumedBy
+
+Outputs consuming this output
+
+```ts
+consumedBy: Array<{
+    txid: string;
+    outputIndex: number;
+}>
+```
+
+#### Property outputIndex
+
+index of the output
+
+```ts
+outputIndex: number
+```
+
+#### Property outputScript
+
+script of the output
+
+```ts
+outputScript: number[]
+```
+
+#### Property outputsConsumed
+
+Outputs consumed by the transaction associated with the output
+
+```ts
+outputsConsumed: Array<{
+    txid: string;
+    outputIndex: number;
+}>
+```
+
+#### Property satoshis
+
+number of satoshis in the output
+
+```ts
+satoshis: number
+```
+
+#### Property spent
+
+Whether the output is spent
+
+```ts
+spent: boolean
+```
+
+#### Property topic
+
+topic to which the output belongs
+
+```ts
+topic: string
+```
+
+#### Property txid
+
+TXID of the output
+
+```ts
+txid: string
+```
+
+</details>
+
 Links: [API](#api), [Interfaces](#interfaces), [Classes](#classes), [Functions](#functions), [Types](#types)
 
 ---
@@ -184,6 +374,10 @@ Defines the Storage Engine interface used internally by the Overlay Services Eng
 export interface Storage {
     insertOutput: (utxo: Output) => Promise<void>;
     findOutput: (txid: string, outputIndex: number, topic?: string, spent?: boolean, includeBEEF?: boolean) => Promise<Output | null>;
+    findOutputsByOutpoints?: (outpoints: Array<{
+        txid: string;
+        outputIndex: number;
+    }>, includeBEEF?: boolean) => Promise<Output[]>;
     findOutputsForTransaction: (txid: string, includeBEEF?: boolean) => Promise<Output[]>;
     findUTXOsForTopic: (topic: string, since?: number, limit?: number, includeBEEF?: boolean) => Promise<Output[]>;
     deleteOutput: (txid: string, outputIndex: number, topic: string) => Promise<void>;
@@ -202,6 +396,138 @@ export interface Storage {
 ```
 
 See also: [AppliedTransaction](#interface-appliedtransaction), [Output](#interface-output)
+
+<details>
+
+<summary>Interface Storage Details</summary>
+
+#### Property deleteOutput
+
+Deletes an output from storage
+
+```ts
+deleteOutput: (txid: string, outputIndex: number, topic: string) => Promise<void>
+```
+
+#### Property doesAppliedTransactionExist
+
+Checks if a duplicate transaction exists
+
+```ts
+doesAppliedTransactionExist: (tx: AppliedTransaction) => Promise<boolean>
+```
+See also: [AppliedTransaction](#interface-appliedtransaction)
+
+#### Property findOutput
+
+Finds an output from storage
+
+```ts
+findOutput: (txid: string, outputIndex: number, topic?: string, spent?: boolean, includeBEEF?: boolean) => Promise<Output | null>
+```
+See also: [Output](#interface-output)
+
+#### Property findOutputsByOutpoints
+
+Finds multiple outputs from storage by txid/output index pairs.
+Implementations can use this to collapse many point lookups into a single query.
+
+```ts
+findOutputsByOutpoints?: (outpoints: Array<{
+    txid: string;
+    outputIndex: number;
+}>, includeBEEF?: boolean) => Promise<Output[]>
+```
+See also: [Output](#interface-output)
+
+#### Property findOutputsForTransaction
+
+Finds outputs with a matching transaction ID from storage
+
+```ts
+findOutputsForTransaction: (txid: string, includeBEEF?: boolean) => Promise<Output[]>
+```
+See also: [Output](#interface-output)
+
+#### Property findUTXOsForTopic
+
+Finds current UTXOs that have been admitted into a given topic
+
+```ts
+findUTXOsForTopic: (topic: string, since?: number, limit?: number, includeBEEF?: boolean) => Promise<Output[]>
+```
+See also: [Output](#interface-output)
+
+#### Property getLastInteraction
+
+Retrieves the last interaction score for a given host and topic
+
+```ts
+getLastInteraction: (host: string, topic: string) => Promise<number>
+```
+
+#### Property insertAppliedTransaction
+
+Inserts record of the applied transaction
+
+```ts
+insertAppliedTransaction: (tx: AppliedTransaction) => Promise<void>
+```
+See also: [AppliedTransaction](#interface-appliedtransaction)
+
+#### Property insertOutput
+
+Adds a new output to storage
+
+```ts
+insertOutput: (utxo: Output) => Promise<void>
+```
+See also: [Output](#interface-output)
+
+#### Property markUTXOAsSpent
+
+Updates a UTXO as spent
+
+```ts
+markUTXOAsSpent: (txid: string, outputIndex: number, topic: string) => Promise<void>
+```
+
+#### Property updateConsumedBy
+
+Updates which outputs are consumed by this output
+
+```ts
+updateConsumedBy: (txid: string, outputIndex: number, topic: string, consumedBy: Array<{
+    txid: string;
+    outputIndex: number;
+}>) => Promise<void>
+```
+
+#### Property updateLastInteraction
+
+Updates the last interaction score for a given host and topic
+
+```ts
+updateLastInteraction: (host: string, topic: string, since: number) => Promise<void>
+```
+
+#### Property updateOutputBlockHeight
+
+Updates the block height on an output
+
+```ts
+updateOutputBlockHeight?: (txid: string, outputIndex: number, topic: string, blockHeight: number) => Promise<void>
+```
+
+#### Property updateTransactionBEEF
+
+Updates the beef data for a transaction
+
+```ts
+updateTransactionBEEF: (txid: string, beef: number[]) => Promise<void>
+```
+
+</details>
 
 Links: [API](#api), [Interfaces](#interfaces), [Classes](#classes), [Functions](#functions), [Types](#types)
 
@@ -227,6 +553,55 @@ export interface TopicManager {
     }>;
 }
 ```
+
+<details>
+
+<summary>Interface TopicManager Details</summary>
+
+#### Property getDocumentation
+
+Returns a Markdown-formatted documentation string for the topic manager.
+
+```ts
+getDocumentation: () => Promise<string>
+```
+
+#### Property getMetaData
+
+Returns a metadata object that can be used to identify the topic manager.
+
+```ts
+getMetaData: () => Promise<{
+    name: string;
+    shortDescription: string;
+    iconURL?: string;
+    version?: string;
+    informationURL?: string;
+}>
+```
+
+#### Property identifyAdmissibleOutputs
+
+Returns instructions that denote which outputs from the provided transaction to admit into the topic, and which previous coins should be retained.
+Accepts the transaction in BEEF format and an array of those input indices which spend previously-admitted outputs from the same topic.
+The transaction's BEEF structure will always contain the transactions associated with previous coins for reference (if any), regardless of whether the current transaction was directly proven.
+
+```ts
+identifyAdmissibleOutputs: (beef: number[], previousCoins: number[], offChainValues?: number[], mode?: "historical-tx" | "current-tx" | "historical-tx-no-spv") => Promise<AdmittanceInstructions>
+```
+
+#### Property identifyNeededInputs
+
+Identifies and returns the inputs needed to anchor any topical outputs from this transaction to their associated previous history.
+
+```ts
+identifyNeededInputs?: (beef: number[], offChainValues?: number[]) => Promise<Array<{
+    txid: string;
+    outputIndex: number;
+}>>
+```
+
+</details>
 
 Links: [API](#api), [Interfaces](#interfaces), [Classes](#classes), [Functions](#functions), [Types](#types)
 
@@ -254,31 +629,31 @@ export class Engine {
         [key: string]: TopicManager;
     }, public lookupServices: {
         [key: string]: LookupService;
-    }, public storage: Storage, public chainTracker: ChainTracker | "scripts only", public hostingURL?: string, public shipTrackers?: string[], public slapTrackers?: string[], public broadcaster?: Broadcaster, public advertiser?: Advertiser, public syncConfiguration?: SyncConfiguration, public logTime = false, public logPrefix = "[OVERLAY_ENGINE] ", public throwOnBroadcastFailure = false, public overlayBroadcastFacilitator: OverlayBroadcastFacilitator = new HTTPSOverlayBroadcastFacilitator(), public logger: typeof console = console, public suppressDefaultSyncAdvertisements = true) 
-    async submit(taggedBEEF: TaggedBEEF, onSteakReady?: (steak: STEAK) => void, mode: "historical-tx" | "current-tx" | "historical-tx-no-spv" = "current-tx", offChainValues?: number[]): Promise<STEAK> 
-    async lookup(lookupQuestion: LookupQuestion): Promise<LookupAnswer> 
-    async syncAdvertisements(): Promise<void> 
-    async startGASPSync(): Promise<void> 
-    async provideForeignSyncResponse(initialRequest: GASPInitialRequest, topic: string): Promise<GASPInitialResponse> 
-    async provideForeignGASPNode(graphID: string, txid: string, outputIndex: number): Promise<GASPNode> 
-    async getUTXOHistory(output: Output, historySelector?: ((beef: number[], outputIndex: number, currentDepth: number) => Promise<boolean>) | number, currentDepth = 0, context: UTXOHistoryHydrationContext = this.createUTXOHistoryHydrationContext()): Promise<Output | undefined> 
-    async handleNewMerkleProof(txid: string, proof: MerklePath, blockHeight?: number): Promise<void> 
+    }, public storage: Storage, public chainTracker: ChainTracker | "scripts only", public hostingURL?: string, public shipTrackers?: string[], public slapTrackers?: string[], public broadcaster?: Broadcaster, public advertiser?: Advertiser, public syncConfiguration?: SyncConfiguration, public logTime = false, public logPrefix = "[OVERLAY_ENGINE] ", public throwOnBroadcastFailure = false, public overlayBroadcastFacilitator: OverlayBroadcastFacilitator = new HTTPSOverlayBroadcastFacilitator(), public logger: typeof console = console, public suppressDefaultSyncAdvertisements = true)
+    async submit(taggedBEEF: TaggedBEEF, onSteakReady?: (steak: STEAK) => void, mode: "historical-tx" | "current-tx" | "historical-tx-no-spv" = "current-tx", offChainValues?: number[]): Promise<STEAK>
+    async lookup(lookupQuestion: LookupQuestion): Promise<LookupAnswer>
+    async syncAdvertisements(): Promise<void>
+    async startGASPSync(): Promise<void>
+    async provideForeignSyncResponse(initialRequest: GASPInitialRequest, topic: string): Promise<GASPInitialResponse>
+    async provideForeignGASPNode(graphID: string, txid: string, outputIndex: number): Promise<GASPNode>
+    async getUTXOHistory(output: Output, historySelector?: ((beef: number[], outputIndex: number, currentDepth: number) => Promise<boolean>) | number, currentDepth = 0, context: UTXOHistoryHydrationContext = this.createUTXOHistoryHydrationContext()): Promise<Output | undefined>
+    async handleNewMerkleProof(txid: string, proof: MerklePath, blockHeight?: number): Promise<void>
     async listTopicManagers(): Promise<Record<string, {
         name: string;
         shortDescription: string;
         iconURL?: string;
         version?: string;
         informationURL?: string;
-    }>> 
+    }>>
     async listLookupServiceProviders(): Promise<Record<string, {
         name: string;
         shortDescription: string;
         iconURL?: string;
         version?: string;
         informationURL?: string;
-    }>> 
-    async getDocumentationForTopicManager(manager: any): Promise<string> 
-    async getDocumentationForLookupServiceProvider(provider: any): Promise<string> 
+    }>>
+    async getDocumentationForTopicManager(manager: any): Promise<string>
+    async getDocumentationForLookupServiceProvider(provider: any): Promise<string>
 }
 ```
 
@@ -297,7 +672,7 @@ constructor(public managers: {
     [key: string]: TopicManager;
 }, public lookupServices: {
     [key: string]: LookupService;
-}, public storage: Storage, public chainTracker: ChainTracker | "scripts only", public hostingURL?: string, public shipTrackers?: string[], public slapTrackers?: string[], public broadcaster?: Broadcaster, public advertiser?: Advertiser, public syncConfiguration?: SyncConfiguration, public logTime = false, public logPrefix = "[OVERLAY_ENGINE] ", public throwOnBroadcastFailure = false, public overlayBroadcastFacilitator: OverlayBroadcastFacilitator = new HTTPSOverlayBroadcastFacilitator(), public logger: typeof console = console, public suppressDefaultSyncAdvertisements = true) 
+}, public storage: Storage, public chainTracker: ChainTracker | "scripts only", public hostingURL?: string, public shipTrackers?: string[], public slapTrackers?: string[], public broadcaster?: Broadcaster, public advertiser?: Advertiser, public syncConfiguration?: SyncConfiguration, public logTime = false, public logPrefix = "[OVERLAY_ENGINE] ", public throwOnBroadcastFailure = false, public overlayBroadcastFacilitator: OverlayBroadcastFacilitator = new HTTPSOverlayBroadcastFacilitator(), public logger: typeof console = console, public suppressDefaultSyncAdvertisements = true)
 ```
 See also: [Advertiser](#interface-advertiser), [LookupService](#interface-lookupservice), [Storage](#interface-storage), [SyncConfiguration](#type-syncconfiguration), [TopicManager](#interface-topicmanager)
 
@@ -341,7 +716,7 @@ Argument Details
 Run a query to get the documentation for a particular lookup service
 
 ```ts
-async getDocumentationForLookupServiceProvider(provider: any): Promise<string> 
+async getDocumentationForLookupServiceProvider(provider: any): Promise<string>
 ```
 
 Returns
@@ -353,7 +728,7 @@ Returns
 Run a query to get the documentation for a particular topic manager
 
 ```ts
-async getDocumentationForTopicManager(manager: any): Promise<string> 
+async getDocumentationForTopicManager(manager: any): Promise<string>
 ```
 
 Returns
@@ -368,7 +743,7 @@ This method traverses the history of a given Unspent Transaction Output (UTXO) a
 its historical data based on the provided history selector and current depth.
 
 ```ts
-async getUTXOHistory(output: Output, historySelector?: ((beef: number[], outputIndex: number, currentDepth: number) => Promise<boolean>) | number, currentDepth = 0, context: UTXOHistoryHydrationContext = this.createUTXOHistoryHydrationContext()): Promise<Output | undefined> 
+async getUTXOHistory(output: Output, historySelector?: ((beef: number[], outputIndex: number, currentDepth: number) => Promise<boolean>) | number, currentDepth = 0, context: UTXOHistoryHydrationContext = this.createUTXOHistoryHydrationContext()): Promise<Output | undefined>
 ```
 See also: [Output](#interface-output)
 
@@ -393,7 +768,7 @@ returning a promise that resolves to a boolean indicating whether to include the
 Recursively prune UTXOs when an incoming Merkle Proof is received.
 
 ```ts
-async handleNewMerkleProof(txid: string, proof: MerklePath, blockHeight?: number): Promise<void> 
+async handleNewMerkleProof(txid: string, proof: MerklePath, blockHeight?: number): Promise<void>
 ```
 
 Argument Details
@@ -416,7 +791,7 @@ async listLookupServiceProviders(): Promise<Record<string, {
     iconURL?: string;
     version?: string;
     informationURL?: string;
-}>> 
+}>>
 ```
 
 Returns
@@ -434,7 +809,7 @@ async listTopicManagers(): Promise<Record<string, {
     iconURL?: string;
     version?: string;
     informationURL?: string;
-}>> 
+}>>
 ```
 
 Returns
@@ -446,7 +821,7 @@ Returns
 Submit a lookup question to the Overlay Services Engine, and receive back a Lookup Answer
 
 ```ts
-async lookup(lookupQuestion: LookupQuestion): Promise<LookupAnswer> 
+async lookup(lookupQuestion: LookupQuestion): Promise<LookupAnswer>
 ```
 
 Returns
@@ -463,7 +838,7 @@ Argument Details
 Provides a GASPNode for the given graphID, transaction ID, and output index.
 
 ```ts
-async provideForeignGASPNode(graphID: string, txid: string, outputIndex: number): Promise<GASPNode> 
+async provideForeignGASPNode(graphID: string, txid: string, outputIndex: number): Promise<GASPNode>
 ```
 
 Returns
@@ -492,7 +867,7 @@ since the provided block height in the request. It constructs a response that in
 and the min block height from the initial request.
 
 ```ts
-async provideForeignSyncResponse(initialRequest: GASPInitialRequest, topic: string): Promise<GASPInitialResponse> 
+async provideForeignSyncResponse(initialRequest: GASPInitialRequest, topic: string): Promise<GASPInitialResponse>
 ```
 
 Returns
@@ -513,7 +888,7 @@ associated with that topic. If the sync configuration is 'SHIP', it will sync to
 the topic.
 
 ```ts
-async startGASPSync(): Promise<void> 
+async startGASPSync(): Promise<void>
 ```
 
 Throws
@@ -525,7 +900,7 @@ Error if the overlay service engine is not configured for topical synchronizatio
 Submits a transaction for processing by Overlay Services.
 
 ```ts
-async submit(taggedBEEF: TaggedBEEF, onSteakReady?: (steak: STEAK) => void, mode: "historical-tx" | "current-tx" | "historical-tx-no-spv" = "current-tx", offChainValues?: number[]): Promise<STEAK> 
+async submit(taggedBEEF: TaggedBEEF, onSteakReady?: (steak: STEAK) => void, mode: "historical-tx" | "current-tx" | "historical-tx-no-spv" = "current-tx", offChainValues?: number[]): Promise<STEAK>
 ```
 
 Returns
@@ -563,7 +938,7 @@ The function uses the `Advertiser` methods to create or revoke advertisements an
 submitted to the SHIP/SLAP overlay networks using the engine's `submit()` method.
 
 ```ts
-async syncAdvertisements(): Promise<void> 
+async syncAdvertisements(): Promise<void>
 ```
 
 Returns
@@ -584,29 +959,33 @@ Links: [API](#api), [Interfaces](#interfaces), [Classes](#classes), [Functions](
 ```ts
 export class KnexStorage implements Storage {
     knex: Knex;
-    constructor(knex: Knex) 
-    async findOutput(txid: string, outputIndex: number, topic?: string, spent?: boolean, includeBEEF: boolean = false): Promise<Output | null> 
-    async findOutputsForTransaction(txid: string, includeBEEF: boolean = false): Promise<Output[]> 
-    async findUTXOsForTopic(topic: string, since?: number, limit?: number, includeBEEF: boolean = false): Promise<Output[]> 
-    async deleteOutput(txid: string, outputIndex: number, _: string): Promise<void> 
-    async insertOutput(output: Output): Promise<void> 
-    async markUTXOAsSpent(txid: string, outputIndex: number, topic?: string): Promise<void> 
+    constructor(knex: Knex)
+    async findOutput(txid: string, outputIndex: number, topic?: string, spent?: boolean, includeBEEF: boolean = false): Promise<Output | null>
+    async findOutputsByOutpoints(outpoints: Array<{
+        txid: string;
+        outputIndex: number;
+    }>, includeBEEF: boolean = false): Promise<Output[]>
+    async findOutputsForTransaction(txid: string, includeBEEF: boolean = false): Promise<Output[]>
+    async findUTXOsForTopic(topic: string, since?: number, limit?: number, includeBEEF: boolean = false): Promise<Output[]>
+    async deleteOutput(txid: string, outputIndex: number, _: string): Promise<void>
+    async insertOutput(output: Output): Promise<void>
+    async markUTXOAsSpent(txid: string, outputIndex: number, topic?: string): Promise<void>
     async updateConsumedBy(txid: string, outputIndex: number, topic: string, consumedBy: Array<{
         txid: string;
         outputIndex: number;
-    }>): Promise<void> 
-    async updateTransactionBEEF(txid: string, beef: number[]): Promise<void> 
-    async updateOutputBlockHeight(txid: string, outputIndex: number, topic: string, blockHeight: number): Promise<void> 
+    }>): Promise<void>
+    async updateTransactionBEEF(txid: string, beef: number[]): Promise<void>
+    async updateOutputBlockHeight(txid: string, outputIndex: number, topic: string, blockHeight: number): Promise<void>
     async insertAppliedTransaction(tx: {
         txid: string;
         topic: string;
-    }): Promise<void> 
+    }): Promise<void>
     async doesAppliedTransactionExist(tx: {
         txid: string;
         topic: string;
-    }): Promise<boolean> 
-    async updateLastInteraction(host: string, topic: string, since: number): Promise<void> 
-    async getLastInteraction(host: string, topic: string): Promise<number> 
+    }): Promise<boolean>
+    async updateLastInteraction(host: string, topic: string, since: number): Promise<void>
+    async getLastInteraction(host: string, topic: string): Promise<number>
 }
 ```
 
@@ -619,11 +998,11 @@ Links: [API](#api), [Interfaces](#interfaces), [Classes](#classes), [Functions](
 
 ```ts
 export class OverlayGASPRemote implements GASPRemote {
-    constructor(public endpointURL: string, public topic: string) 
-    async getInitialResponse(request: GASPInitialRequest): Promise<GASPInitialResponse> 
-    async requestNode(graphID: string, txid: string, outputIndex: number, metadata: boolean): Promise<GASPNode> 
-    async getInitialReply(response: GASPInitialResponse): Promise<GASPInitialReply> 
-    async submitNode(node: GASPNode): Promise<GASPNodeResponse | undefined> 
+    constructor(public endpointURL: string, public topic: string)
+    async getInitialResponse(request: GASPInitialRequest): Promise<GASPInitialResponse>
+    async requestNode(graphID: string, txid: string, outputIndex: number, metadata: boolean): Promise<GASPNode>
+    async getInitialReply(response: GASPInitialResponse): Promise<GASPInitialReply>
+    async submitNode(node: GASPNode): Promise<GASPNodeResponse | undefined>
 }
 ```
 
@@ -636,7 +1015,7 @@ export class OverlayGASPRemote implements GASPRemote {
 Given an outgoing initial request, sends the request to the foreign instance and obtains their initial response.
 
 ```ts
-async getInitialResponse(request: GASPInitialRequest): Promise<GASPInitialResponse> 
+async getInitialResponse(request: GASPInitialRequest): Promise<GASPInitialResponse>
 ```
 
 #### Method requestNode
@@ -644,7 +1023,7 @@ async getInitialResponse(request: GASPInitialRequest): Promise<GASPInitialRespon
 Given an outgoing txid, outputIndex and optional metadata, request the associated GASP node from the foreign instance.
 
 ```ts
-async requestNode(graphID: string, txid: string, outputIndex: number, metadata: boolean): Promise<GASPNode> 
+async requestNode(graphID: string, txid: string, outputIndex: number, metadata: boolean): Promise<GASPNode>
 ```
 
 </details>
@@ -657,14 +1036,14 @@ Links: [API](#api), [Interfaces](#interfaces), [Classes](#classes), [Functions](
 ```ts
 export class OverlayGASPStorage implements GASPStorage {
     readonly temporaryGraphNodeRefs: Record<string, GraphNode> = {};
-    constructor(public topic: string, public engine: Engine, public maxNodesInGraph?: number) 
-    async findKnownUTXOs(since: number): Promise<GASPOutput[]> 
-    async hydrateGASPNode(graphID: string, txid: string, outputIndex: number, metadata: boolean): Promise<GASPNode> 
-    async findNeededInputs(tx: GASPNode): Promise<GASPNodeResponse | undefined> 
-    async appendToGraph(tx: GASPNode, spentBy?: string | undefined): Promise<void> 
-    async validateGraphAnchor(graphID: string): Promise<void> 
-    async discardGraph(graphID: string): Promise<void> 
-    async finalizeGraph(graphID: string): Promise<void> 
+    constructor(public topic: string, public engine: Engine, public maxNodesInGraph?: number)
+    async findKnownUTXOs(since: number): Promise<GASPOutput[]>
+    async hydrateGASPNode(graphID: string, txid: string, outputIndex: number, metadata: boolean): Promise<GASPNode>
+    async findNeededInputs(tx: GASPNode): Promise<GASPNodeResponse | undefined>
+    async appendToGraph(tx: GASPNode, spentBy?: string | undefined): Promise<void>
+    async validateGraphAnchor(graphID: string): Promise<void>
+    async discardGraph(graphID: string): Promise<void>
+    async finalizeGraph(graphID: string): Promise<void>
 }
 ```
 
@@ -679,7 +1058,7 @@ See also: [Engine](#class-engine), [GraphNode](#interface-graphnode)
 Appends a new node to a temporary graph.
 
 ```ts
-async appendToGraph(tx: GASPNode, spentBy?: string | undefined): Promise<void> 
+async appendToGraph(tx: GASPNode, spentBy?: string | undefined): Promise<void>
 ```
 
 Argument Details
@@ -698,7 +1077,7 @@ If the node cannot be appended to the graph, either because the graph ID is for 
 Deletes all data associated with a temporary graph that has failed to sync, if the graph exists.
 
 ```ts
-async discardGraph(graphID: string): Promise<void> 
+async discardGraph(graphID: string): Promise<void>
 ```
 
 Argument Details
@@ -711,7 +1090,7 @@ Argument Details
 Finalizes a graph, solidifying the new UTXO and its ancestors so that it will appear in the list of known UTXOs.
 
 ```ts
-async finalizeGraph(graphID: string): Promise<void> 
+async finalizeGraph(graphID: string): Promise<void>
 ```
 
 Argument Details
@@ -724,7 +1103,7 @@ Argument Details
 For a given node, returns the inputs needed to complete the graph, including whether updated metadata is requested for those inputs.
 
 ```ts
-async findNeededInputs(tx: GASPNode): Promise<GASPNodeResponse | undefined> 
+async findNeededInputs(tx: GASPNode): Promise<GASPNodeResponse | undefined>
 ```
 
 Returns
@@ -741,7 +1120,7 @@ Argument Details
 For a given txid and output index, returns the associated transaction, a merkle proof if the transaction is in a block, and metadata if if requested. If no metadata is requested, metadata hashes on inputs are not returned.
 
 ```ts
-async hydrateGASPNode(graphID: string, txid: string, outputIndex: number, metadata: boolean): Promise<GASPNode> 
+async hydrateGASPNode(graphID: string, txid: string, outputIndex: number, metadata: boolean): Promise<GASPNode>
 ```
 
 #### Method validateGraphAnchor
@@ -751,7 +1130,7 @@ Additionally, in a breadth-first manner (ensuring that all inputs for any given 
 while considering any coins which the Manager had previously indicated were either valid or invalid.
 
 ```ts
-async validateGraphAnchor(graphID: string): Promise<void> 
+async validateGraphAnchor(graphID: string): Promise<void>
 ```
 
 Argument Details
@@ -770,10 +1149,16 @@ Links: [API](#api), [Interfaces](#interfaces), [Classes](#classes), [Functions](
 ---
 ## Functions
 
-| |
-| --- |
-| [down](#function-down) |
-| [up](#function-up) |
+| | |
+| --- | --- |
+| [down](#function-down) | [up](#function-up) |
+| [down](#function-down) | [up](#function-up) |
+| [down](#function-down) | [up](#function-up) |
+| [down](#function-down) | [up](#function-up) |
+| [down](#function-down) | [up](#function-up) |
+| [down](#function-down) | [up](#function-up) |
+| [down](#function-down) | [up](#function-up) |
+| [down](#function-down) | [up](#function-up) |
 
 Links: [API](#api), [Interfaces](#interfaces), [Classes](#classes), [Functions](#functions), [Types](#types)
 
@@ -783,6 +1168,132 @@ Links: [API](#api), [Interfaces](#interfaces), [Classes](#classes), [Functions](
 
 ```ts
 export async function down(knex: Knex): Promise<void>
+```
+
+Links: [API](#api), [Interfaces](#interfaces), [Classes](#classes), [Functions](#functions), [Types](#types)
+
+---
+### Function: down
+
+```ts
+export async function down(knex: Knex): Promise<void>
+```
+
+Links: [API](#api), [Interfaces](#interfaces), [Classes](#classes), [Functions](#functions), [Types](#types)
+
+---
+### Function: down
+
+```ts
+export async function down(knex: Knex): Promise<void>
+```
+
+Links: [API](#api), [Interfaces](#interfaces), [Classes](#classes), [Functions](#functions), [Types](#types)
+
+---
+### Function: down
+
+```ts
+export async function down(knex: Knex): Promise<void>
+```
+
+Links: [API](#api), [Interfaces](#interfaces), [Classes](#classes), [Functions](#functions), [Types](#types)
+
+---
+### Function: down
+
+```ts
+export async function down(knex: Knex): Promise<void>
+```
+
+Links: [API](#api), [Interfaces](#interfaces), [Classes](#classes), [Functions](#functions), [Types](#types)
+
+---
+### Function: down
+
+```ts
+export async function down(knex: Knex): Promise<void>
+```
+
+Links: [API](#api), [Interfaces](#interfaces), [Classes](#classes), [Functions](#functions), [Types](#types)
+
+---
+### Function: down
+
+```ts
+export async function down(knex: Knex): Promise<void>
+```
+
+Links: [API](#api), [Interfaces](#interfaces), [Classes](#classes), [Functions](#functions), [Types](#types)
+
+---
+### Function: down
+
+```ts
+export async function down(knex: Knex): Promise<void>
+```
+
+Links: [API](#api), [Interfaces](#interfaces), [Classes](#classes), [Functions](#functions), [Types](#types)
+
+---
+### Function: up
+
+```ts
+export async function up(knex: Knex): Promise<void>
+```
+
+Links: [API](#api), [Interfaces](#interfaces), [Classes](#classes), [Functions](#functions), [Types](#types)
+
+---
+### Function: up
+
+```ts
+export async function up(knex: Knex): Promise<void>
+```
+
+Links: [API](#api), [Interfaces](#interfaces), [Classes](#classes), [Functions](#functions), [Types](#types)
+
+---
+### Function: up
+
+```ts
+export async function up(knex: Knex): Promise<void>
+```
+
+Links: [API](#api), [Interfaces](#interfaces), [Classes](#classes), [Functions](#functions), [Types](#types)
+
+---
+### Function: up
+
+```ts
+export async function up(knex: Knex): Promise<void>
+```
+
+Links: [API](#api), [Interfaces](#interfaces), [Classes](#classes), [Functions](#functions), [Types](#types)
+
+---
+### Function: up
+
+```ts
+export async function up(knex: Knex): Promise<void>
+```
+
+Links: [API](#api), [Interfaces](#interfaces), [Classes](#classes), [Functions](#functions), [Types](#types)
+
+---
+### Function: up
+
+```ts
+export async function up(knex: Knex): Promise<void>
+```
+
+Links: [API](#api), [Interfaces](#interfaces), [Classes](#classes), [Functions](#functions), [Types](#types)
+
+---
+### Function: up
+
+```ts
+export async function up(knex: Knex): Promise<void>
 ```
 
 Links: [API](#api), [Interfaces](#interfaces), [Classes](#classes), [Functions](#functions), [Types](#types)
@@ -939,6 +1450,3 @@ export type SyncConfiguration = Record<string, string[] | "SHIP" | false>
 Links: [API](#api), [Interfaces](#interfaces), [Classes](#classes), [Functions](#functions), [Types](#types)
 
 ---
-
-[🏠 Home](./README.md) | [📚 API](./API.md) | [💡 Concepts](./concepts/README.md) | [📖 Examples](./examples/README.md) | [⚙️ Internal](./internal/README.md)
-

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -4,11 +4,11 @@
 
 ---
 
-Here, you will find documentation for common example usages of the Overlay Services Engine.
+Here, you will find documentation for common example usages of the Overlay Services Engine. These examples focus on direct `@bsv/overlay` integration. For a ready-to-run HTTP overlay node, use [`@bsv/overlay-express`](https://github.com/bsv-blockchain/overlay-express) and [`overlay-express-examples`](https://github.com/bsv-blockchain/overlay-express-examples).
 
 ## Available Examples
 
-- [Getting Started (WIP)](./gs-wip.md) — Introduction and getting started guide
+- [Getting Started](./gs-wip.md) — Introduction and low-level engine setup guide
 
 ---
 

--- a/docs/examples/gs-wip.md
+++ b/docs/examples/gs-wip.md
@@ -6,106 +6,114 @@
 
 ## Introduction to BSV Overlay Services Engine
 
-The BSV Overlay Services Engine is designed to process transactions and manage data within a blockchain-based system, specifically targeting the Bitcoin SV (BSV) blockchain. It integrates various components such as Topic Managers, Lookup Services, Storage, and Chain Tracker to provide a robust environment for managing transaction data and overlay services.
+The BSV Overlay Services Engine is the low-level runtime for topic managers and lookup services. It validates candidate outputs, stores admitted UTXOs, tracks spends, answers lookup questions, and coordinates synchronization between overlay nodes.
+
+If you want to run an HTTP overlay node, start with [`@bsv/overlay-express`](https://github.com/bsv-blockchain/overlay-express). If you want a local or cloud application runtime, use LARS or CARS with the BRC-102 `deployment-info.json` structure. Use `@bsv/overlay` directly when you are building custom infrastructure around the engine.
 
 ### Components of the System
 
-1. **Topic Managers**: Responsible for managing the admittance of transactions related to specific topics.
-2. **Lookup Services**: Handle the lookup of UTXO (Unspent Transaction Output) data for transactions.
-3. **Storage**: Manages persistent data storage, tracking UTXOs and their states within the system.
-4. **Chain Tracker**: Verifies SPV (Simplified Payment Verification) data associated with transactions to ensure their validity.
+1. **Topic Managers** decide which transaction outputs are admitted for a topic.
+2. **Lookup Services** index admitted and spent outputs and answer domain-specific lookup questions.
+3. **Storage** persists admitted outputs, spend state, history, sync state, and interaction timestamps.
+4. **Chain Tracker** verifies SPV data for transactions unless the engine is configured for script-only validation.
+5. **Broadcaster** submits accepted transactions to the network.
+6. **Advertiser** publishes SHIP and SLAP availability records when peer discovery is enabled.
 
 ### Setting Up the Engine
 
-Before you can use the engine, you must initialize it with the required components:
+Install the current packages:
+
+```bash
+npm i @bsv/overlay @bsv/sdk knex
+```
+
+Create the engine with your concrete implementations:
 
 ```ts
-import { Engine, KnexStorage } from "@bsv/overlay";
-import { HelloTopicManager, HelloLookupService } from 'hello-services';
-import { WoChain } from "@bsv/sdk";
+import { Engine, KnexStorage } from '@bsv/overlay'
+import { WhatsOnChain, NodejsHttpClient, ARC } from '@bsv/sdk'
+import knexFactory from 'knex'
 
-// Initialize components
-const managers = {
-    "exampleTopic": new HelloTopicManager()
-};
+import { ExampleLookupService } from './services/ExampleLookupService.js'
+import { ExampleTopicManager } from './services/ExampleTopicManager.js'
 
-const lookupServices = {
-    "exampleLookup": new HelloLookupService()
-};
+const knex = knexFactory({
+  client: 'mysql2',
+  connection: process.env.KNEX_URL
+})
 
-const storage = new KnexStorage();
-const chainTracker = new WoChain();
-
-// Create the engine instance
-const engine = new Engine(managers, lookupServices, storage, chainTracker);
+const engine = new Engine(
+  {
+    tm_example: new ExampleTopicManager()
+  },
+  {
+    ls_example: new ExampleLookupService()
+  },
+  new KnexStorage(knex),
+  new WhatsOnChain('test', { httpClient: new NodejsHttpClient() }),
+  process.env.HOSTING_URL,
+  process.env.SHIP_TRACKERS?.split(',') ?? [],
+  process.env.SLAP_TRACKERS?.split(',') ?? [],
+  new ARC(process.env.ARC_URL ?? 'https://arc.taal.com', {
+    apiKey: process.env.ARC_API_KEY
+  }),
+  undefined,
+  {
+    tm_example: 'SHIP'
+  }
+)
 ```
+
+Use the string `'scripts only'` for the chain tracker only when the service intentionally skips SPV validation and relies only on script-level checks.
 
 ### Submitting a Transaction
 
-To submit a transaction for processing by the Overlay Services:
+Submit tagged BEEF bytes with the topics that should evaluate the transaction:
 
 ```ts
 import { Transaction } from '@bsv/sdk'
 
-const tx = new Transaction(/* ... */);
+const tx = new Transaction(/* ... */)
 
-const transaction = {
-    beef: tx.toBEEF(),
-    topics: ['exampleTopic']
-}
+const steak = await engine.submit({
+  beef: tx.toBEEF(),
+  topics: ['tm_example']
+})
 
-// Submit transaction
-engine.submit(transaction).then(steak => {
-    console.log("Transaction processed:", steak);
-}).catch(error => {
-    console.error("Error processing transaction:", error);
-});
+console.log('Transaction processed:', steak)
 ```
 
 ### Lookup Queries
 
-To perform a lookup query using the engine:
+Ask a lookup service a domain-specific question:
 
 ```ts
-const question = {
-    service: 'exampleLookup',
-    query: {
-        name: 'Bob'
-    }
-}
+const answer = await engine.lookup({
+  service: 'ls_example',
+  query: {
+    identityKey: '03...'
+  }
+})
 
-// Perform a lookup
-engine.lookup(question).then(answer => {
-    console.log("Lookup result:", answer);
-}).catch(error => {
-    console.error("Error performing lookup:", error);
-});
+console.log('Lookup result:', answer)
 ```
 
-### Managing UTXOs
+### Service Documentation
 
-The system's core functionality involves managing UTXOs:
-
-1. **Inserting a New UTXO**: Store new UTXO data when transactions are processed.
-2. **Deleting a UTXO**: Remove UTXOs that are no longer needed or have been consumed by newer transactions.
-3. **Tracking UTXO Consumption**: Monitor which transactions consume which UTXOs.
-
-### Retrieving Documentation
-
-To retrieve documentation for specific managers or services:
+Overlay clients and dashboards can retrieve service documentation and metadata directly from the engine:
 
 ```ts
-// For a topic manager
-engine.getDocumentationForTopicManger("exampleTopic").then(doc => {
-    console.log("Documentation for Topic Manager:", doc);
-});
+const topicDocs = await engine.getDocumentationForTopicManger('tm_example')
+const lookupDocs = await engine.getDocumentationForLookupServiceProvider('ls_example')
 
-// For a lookup service
-engine.getDocumentationForLookupServiceProvider("exampleLookup").then(doc => {
-    console.log("Documentation for Lookup Service:", doc);
-});
+const topics = await engine.listTopicManagers()
+const lookupServices = await engine.listLookupServiceProviders()
 ```
+
+### Deployment Path
+
+For a public overlay node, wire the engine into HTTP routes using `@bsv/overlay-express` instead of hand-rolling routes. Overlay Express already exposes the standard submit, lookup, sync, health, documentation, and admin surfaces expected by the rest of the BSV overlay ecosystem.
 
 ### Conclusion
 
-The BSV Overlay Services Engine provides a powerful toolset for managing transactions and data on the Bitcoin SV blockchain. It's designed to handle complex data structures and ensure the integrity and security of transactions through rigorous validation and management processes. By following this tutorial, developers can effectively integrate and utilize these capabilities within their blockchain applications.
+The BSV Overlay Services Engine is the shared core for overlay validation, indexing, lookup, and synchronization. Keep direct engine usage focused on infrastructure-level integrations, and use Overlay Express, LARS, and CARS for the standard application path.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@bsv/overlay",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bsv/overlay",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@bsv/gasp": "^1.2.2",
-        "@bsv/sdk": "^2.0.4",
+        "@bsv/sdk": "^2.0.14",
         "knex": "^3.1.0"
       },
       "devDependencies": {
@@ -498,9 +498,9 @@
       }
     },
     "node_modules/@bsv/sdk": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@bsv/sdk/-/sdk-2.0.4.tgz",
-      "integrity": "sha512-5SUK76szpScNmpjx8iupZFWjksz4e4mjzxBbtEaz5LBDjvXeseBFRRmGpeiBnlGtnKd7GVBblW8ZfwjzFM92dg==",
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/@bsv/sdk/-/sdk-2.0.14.tgz",
+      "integrity": "sha512-iCBaq0HG16tmeneGWOltXhOolqj5m8RJFvw08wmwM9XmY9KdqRWuqMeP33NFolBzX13UJ06KODrZdm60svbprA==",
       "license": "SEE LICENSE IN LICENSE.txt"
     },
     "node_modules/@eslint-community/eslint-utils": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bsv/overlay",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "type": "module",
   "description": "BSV Blockchain Overlay Services Engine",
   "main": "dist/cjs/mod.js",
@@ -74,7 +74,7 @@
   },
   "dependencies": {
     "@bsv/gasp": "^1.2.2",
-    "@bsv/sdk": "^2.0.4",
+    "@bsv/sdk": "^2.0.14",
     "knex": "^3.1.0"
   }
 }


### PR DESCRIPTION
## Summary
- Replaces the stale hand-rolled Express getting-started example with current direct Engine guidance.
- Points application developers toward Overlay Express, LARS, CARS, and BRC-102 deployment-info workflows.
- Updates the examples index, regenerates API docs, aligns `@bsv/sdk` to the current v2 package, and bumps `@bsv/overlay` from 2.0.2 to 2.0.3 via `npm version patch`.
 
## Verification
- `npm run doc`
- `npm run lint:ci`
- `npm run test:coverage`